### PR TITLE
Fix non-idempotent runs when lambda with chained call is broken (#640)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fixed
 
 * Fix non-idempotent formatting when a managed trailing comma pushes a line over MAX_WIDTH (e.g. a long qualified expression as the last argument of a call). The comma is now accounted for by re-running the layout, so the line is broken correctly on the first pass. (https://github.com/facebook/ktfmt/pull/636)
+* Fix non-idempotent formatting when max width breaks a scoping-function lambda with a chained call (e.g. `runCatching { ... }.getOrNull()`): the chained call now breaks onto its own line together with the lambda on the first pass. (https://github.com/Kotlin/ktfmt/issues/640)
 
 
 ## [0.64]

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/KotlinInputAstVisitor.kt
@@ -1455,14 +1455,16 @@ open class KotlinInputAstVisitor(
 
     visitLambdaOrScopingFunction(root, emitLeadingBreak = emitLeadingBreak)
 
-    builder.block(expressionBreakIndent) {
-      for (i in 1 until parts.size) {
-        val part = parts[i] as KtQualifiedExpression
-        if (forceBreakBeforeChain) {
-          builder.forcedBreak()
-        } else {
-          builder.breakOp(Doc.FillMode.UNIFIED, "", ZERO)
-        }
+    // The break before each selector must stay outside the block below, at the same level as
+    // the lambda, so that it is taken exactly when the lambda breaks. Inside the block it
+    // would fire only when the selector itself is too long, so a lambda broken by max width
+    // would keep its selector on the closing brace's line — and the next format pass, seeing
+    // a multiline lambda in the source, would force the selector onto its own line (#640).
+    val fillMode = if (forceBreakBeforeChain) Doc.FillMode.FORCED else Doc.FillMode.UNIFIED
+    for (i in 1 until parts.size) {
+      val part = parts[i] as KtQualifiedExpression
+      builder.breakOp(fillMode, "", expressionBreakIndent)
+      builder.block(expressionBreakIndent) {
         builder.token(part.operationSign.value)
         val selectorExpression = part.selectorExpression
         if (selectorExpression is KtCallExpression) {

--- a/core/src/test/resources/cases/format/lambda/preserveLambdaBreaksChainedCall.input
+++ b/core/src/test/resources/cases/format/lambda/preserveLambdaBreaksChainedCall.input
@@ -1,0 +1,9 @@
+// MAX_WIDTH 42
+// BLOCK_INDENT 2
+// CONTINUATION_INDENT 2
+fun test() {
+  scope {
+    val foo =
+      runCatching { someFunction() }.getOrNull()
+  }
+}

--- a/core/src/test/resources/cases/format/lambda/preserveLambdaBreaksChainedCall.output
+++ b/core/src/test/resources/cases/format/lambda/preserveLambdaBreaksChainedCall.output
@@ -1,0 +1,11 @@
+// MAX_WIDTH 42
+// BLOCK_INDENT 2
+// CONTINUATION_INDENT 2
+fun test() {
+  scope {
+    val foo = runCatching {
+      someFunction()
+    }
+      .getOrNull()
+  }
+}


### PR DESCRIPTION
Took a stab at #640, I admit I don't fully grok the AST machinery and had some AI help me with this. But the fix look plausible and all the tests pass