### PR TITLE
Shrink the shadowed JAR with R8

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -50,7 +50,7 @@ val generateSources =
 
 tasks {
   // Run tests with UTF-16 encoding
-  test {
+  withType<Test> {
     useJUnitPlatform()
     jvmArgs("-Dfile.encoding=UTF-16")
   }
@@ -90,6 +90,27 @@ tasks {
     archiveClassifier = "with-dependencies"
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     failOnDuplicateEntries = true
+    minimize {
+      r8 {
+        keepRuleFiles.from(layout.projectDirectory.file("src/main/rules.txt"))
+      }
+    }
+  }
+
+  val testShadow =
+      register("testShadow", Test::class) {
+        group = "verification"
+        description =
+            "Runs unit tests against the R8-processed shadowed JAR to ensure Maven API compatibility."
+        // Replace normal Jar with shadowJar in tests.
+        classpath =
+            (sourceSets["test"].runtimeClasspath - sourceSets["main"].output) +
+                files(shadowJar.flatMap { it.archiveFile })
+        testClassesDirs = sourceSets["test"].output.classesDirs
+      }
+
+  check {
+    dependsOn(testShadow)
   }
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -92,7 +92,7 @@ tasks {
     failOnDuplicateEntries = true
     minimize {
       r8 {
-        keepRuleFiles.from(layout.projectDirectory.file("src/main/rules.txt"))
+        proguardRuleFiles.from(layout.projectDirectory.file("src/main/rules.txt"))
       }
     }
   }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -92,6 +92,7 @@ tasks {
     failOnDuplicateEntries = true
     minimize {
       r8 {
+        useDefaultRules = false
         proguardRuleFiles.from(layout.projectDirectory.file("src/main/rules.txt"))
       }
     }

--- a/core/src/main/rules.txt
+++ b/core/src/main/rules.txt
@@ -1,28 +1,52 @@
 -dontobfuscate
+-dontoptimize
 -keepattributes SourceFile, LineNumberTable
 
 
 -dontwarn com.google.auto.**
 -dontwarn gnu.trove.**
--dontwarn kotlin.annotations.jvm.**
--dontwarn kotlinx.coroutines.internal.intellij.**
--dontwarn org.checkerframework.checker.nullness.qual.Nullable
+-dontwarn kotlin.annotations.**
+-dontwarn kotlinx.coroutines.**
+-dontwarn kotlinx.serialization.**
+-dontwarn org.checkerframework.**
 -dontwarn org.jetbrains.annotations.**
 -dontwarn org.jetbrains.kotlin.com.google.errorprone.annotations.**
 -dontwarn org.jetbrains.kotlin.com.google.j2objc.annotations.**
 -dontwarn org.jetbrains.kotlin.com.intellij.util.**
 
 
-# Keep all ktfmt library classes and methods for Maven API, CLI, and unit test compatibility.
--keep class org.jetbrains.ktfmt.** { *; }
-
-# IntelliJ platform classes required for Kotlin AST parsing & CoreApplicationEnvironment.
--keep class org.jetbrains.kotlin.com.intellij.**
-
-# Kotlin AST PSI and KDoc elements (keep constructors for reflective ASTFactory instantiation).
--keepclassmembers class org.jetbrains.kotlin.psi.** {
-    public <init>(...);
+# Main entry point for CLI execution
+-keep class org.jetbrains.ktfmt.cli.Main {
+    public static void main(java.lang.String[]);
 }
--keepclassmembers class org.jetbrains.kotlin.kdoc.** {
-    public <init>(...);
+
+# Keep specific public and test-referenced ktfmt classes
+-keep class org.jetbrains.ktfmt.format.Formatter {
+    public static *** format(...);
+}
+-keep class org.jetbrains.ktfmt.format.FormattingOptions { *; }
+-keep class org.jetbrains.ktfmt.format.FormattingOptions$* { *; }
+-keep class org.jetbrains.ktfmt.format.ParseError { *; }
+-keep class org.jetbrains.ktfmt.format.KotlinInput { *; }
+-keep class org.jetbrains.ktfmt.format.MultilineStringFormatter { *; }
+-keep class org.jetbrains.ktfmt.format.MultilineStringFormatterKt { *; }
+-keep class org.jetbrains.ktfmt.format.Multiline* { *; }
+-keep class org.jetbrains.ktfmt.format.RedundantImportDetector { *; }
+-keep class org.jetbrains.ktfmt.format.RedundantSemicolonDetector { *; }
+-keep class org.jetbrains.ktfmt.format.TrailingCommas { *; }
+-keep class org.jetbrains.ktfmt.format.TrailingComma* { *; }
+-keep class org.jetbrains.ktfmt.kdoc.KDocFormattingOptions { *; }
+-keep class org.jetbrains.ktfmt.kdoc.KDocFormatter { *; }
+-keep class org.jetbrains.ktfmt.kdoc.UtilitiesKt { *; }
+-keep class org.jetbrains.ktfmt.kdoc.Escaping { *; }
+-keep class org.jetbrains.ktfmt.cli.ParsedArgs { *; }
+-keep class org.jetbrains.ktfmt.cli.ParsedArgs$* { *; }
+-keep class org.jetbrains.ktfmt.cli.EditorConfigResolver { *; }
+
+# Kotlin AST PSI and KDoc elements (keep only reflective ASTFactory ASTNode constructors).
+-keepclassmembers class org.jetbrains.kotlin.psi.** {
+    public <init>(org.jetbrains.kotlin.com.intellij.lang.ASTNode);
+}
+-keepclassmembers class org.jetbrains.kotlin.kdoc.psi.impl.** {
+    public <init>(org.jetbrains.kotlin.com.intellij.lang.ASTNode);
 }

--- a/core/src/main/rules.txt
+++ b/core/src/main/rules.txt
@@ -1,0 +1,28 @@
+-dontobfuscate
+-keepattributes SourceFile, LineNumberTable
+
+
+-dontwarn com.google.auto.**
+-dontwarn gnu.trove.**
+-dontwarn kotlin.annotations.jvm.**
+-dontwarn kotlinx.coroutines.internal.intellij.**
+-dontwarn org.checkerframework.checker.nullness.qual.Nullable
+-dontwarn org.jetbrains.annotations.**
+-dontwarn org.jetbrains.kotlin.com.google.errorprone.annotations.**
+-dontwarn org.jetbrains.kotlin.com.google.j2objc.annotations.**
+-dontwarn org.jetbrains.kotlin.com.intellij.util.**
+
+
+# Keep all ktfmt library classes and methods for Maven API, CLI, and unit test compatibility.
+-keep class org.jetbrains.ktfmt.** { *; }
+
+# IntelliJ platform classes required for Kotlin AST parsing & CoreApplicationEnvironment.
+-keep class org.jetbrains.kotlin.com.intellij.**
+
+# Kotlin AST PSI and KDoc elements (keep constructors for reflective ASTFactory instantiation).
+-keepclassmembers class org.jetbrains.kotlin.psi.** {
+    public <init>(...);
+}
+-keepclassmembers class org.jetbrains.kotlin.kdoc.** {
+    public <init>(...);
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ org-junit-junit-bom = "6.1.2"
 gradlePlugin-dependencyAnalysis = "3.18.0"
 gradlePlugin-dokka = "2.2.0"
 gradlePlugin-intelliJPlatform = "2.12.0"
-gradlePlugin-shadowJar = "9.6.1"
+gradlePlugin-shadowJar = "9.7.0-SNAPSHOT"
 
 [libraries]
 ec4j = { module = "org.ec4j.core:ec4j-core", version.ref = "org-ec4j-core" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ org-junit-junit-bom = "6.1.2"
 gradlePlugin-dependencyAnalysis = "3.18.0"
 gradlePlugin-dokka = "2.2.0"
 gradlePlugin-intelliJPlatform = "2.12.0"
-gradlePlugin-shadowJar = "9.0.2"
+gradlePlugin-shadowJar = "9.6.1"
 
 [libraries]
 ec4j = { module = "org.ec4j.core:ec4j-core", version.ref = "org-ec4j-core" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,6 +38,7 @@ dependencyResolutionManagement {
   }
   repositories {
     mavenCentral()
+    google()
   }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@
 
 pluginManagement {
   repositories {
+    maven("https://central.sonatype.com/repository/maven-snapshots/")
     mavenCentral()
     gradlePluginPortal()
   }


### PR DESCRIPTION
```
OLD: old.jar
NEW: new.jar

       │              compressed               │             uncompressed
       ├────────────┬────────────┬─────────────┼────────────┬───────────┬─────────────
 JAR   │ old        │ new        │ diff        │ old        │ new       │ diff
───────┼────────────┼────────────┼─────────────┼────────────┼───────────┼─────────────
 class │  66.07 MiB │  14.71 MiB │  -51.36 MiB │ 167.93 MiB │ 29.43 MiB │  -138.5 MiB
 other │ 996.67 KiB │ 829.11 KiB │ -167.56 KiB │   2.03 MiB │  1.94 MiB │  -86.02 KiB
───────┼────────────┼────────────┼─────────────┼────────────┼───────────┼─────────────
 total │  67.04 MiB │  15.52 MiB │  -51.52 MiB │ 169.96 MiB │ 31.37 MiB │ -138.59 MiB

 CLASSES │ old    │ new   │ diff
─────────┼────────┼───────┼────────────────────────
 classes │  32906 │ 10526 │  -22380 (+1 -22381)
 methods │ 309307 │ 74531 │ -234776 (+268 -235044)
  fields │  78688 │ 23174 │  -55514 (+12 -55526)
```