### PR TITLE
Support editorconfig when using stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Support selected-range formatting in the IntelliJ plugin.
 - GraalVM native image support
 - Support val/var keywords in destructuring entries (https://github.com/facebook/ktfmt/pull/637)
+- Use `--stdin-name` as the EditorConfig lookup path when formatting source from stdin.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ following subset of editorconfig properties:
 | `ij_continuation_indent_size`                             | will override the continuation indent                                                            |
 | `ktfmt_trailing_comma_management_strategy`                | one of `none`, `only_add` or `complete`<br/>will override the trailing comma management strategy |
 
+When formatting source from stdin, pass `--stdin-name=<path>` to resolve EditorConfig settings as if the input were located at that path. The named file does not need to exist and is not read or modified.
+
+```shell
+ktfmt --enable-editorconfig --stdin-name="$PWD/src/Foo.kt" -
+```
+
 #### Preserving Lambda Line Breaks
 
 By default, `ktfmt` respects user-authored line breaks inside lambda bodies. This is useful for DSLs

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/cli/Main.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/cli/Main.kt
@@ -146,9 +146,16 @@ class Main(
   private fun format(file: File?, args: ParsedArgs): Boolean {
     val fileName = file?.toString() ?: args.stdinName ?: "<stdin>"
     try {
+      val editorConfigFile = file ?: args.stdinName?.takeIf { it.isNotEmpty() }?.let(::File)
       val formattingOptions =
-          if (file == null || !args.editorConfig) args.formattingOptions
-          else EditorConfigResolver.resolveFormattingOptions(file, args.formattingOptions)
+          if (!args.editorConfig || editorConfigFile == null) {
+            args.formattingOptions
+          } else {
+            EditorConfigResolver.resolveFormattingOptions(
+              editorConfigFile,
+              args.formattingOptions,
+            )
+          }
       val bytes = if (file == null) input else FileInputStream(file)
       val code = BufferedReader(InputStreamReader(bytes, UTF_8)).readText().removePrefix(UTF8_BOM)
       val formattedCode =

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/cli/Main.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/cli/Main.kt
@@ -152,8 +152,8 @@ class Main(
             args.formattingOptions
           } else {
             EditorConfigResolver.resolveFormattingOptions(
-              editorConfigFile,
-              args.formattingOptions,
+                editorConfigFile,
+                args.formattingOptions,
             )
           }
       val bytes = if (file == null) input else FileInputStream(file)

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/cli/ParsedArgs.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/cli/ParsedArgs.kt
@@ -37,7 +37,7 @@ data class ParsedArgs(
 
     /** Return exit code 1 if any formatting changes are detected. */
     val setExitIfChanged: Boolean,
-    /** File name to report when formating code from stdin */
+    /** Path to report for stdin and, when EditorConfig is enabled, use for configuration lookup. */
     val stdinName: String?,
     val editorConfig: Boolean,
     /** Suppress all non-error output. */
@@ -88,7 +88,8 @@ data class ParsedArgs(
         |  --meta-style                      Use 2-space block indenting (default)
         |  --google-style                    Google internal style (2 spaces)
         |  --kotlinlang-style                Kotlin language guidelines style (4 spaces)
-        |  --stdin-name=<name>               Name to report when formatting code from stdin
+        |  --stdin-name=<path>               Path to report for stdin and, when EditorConfig is
+        |                                        enabled, use for configuration lookup
         |  --lines=<lines>                   Line range(s) to format, like 5 or 1:12,14.
         |                                        May be used multiple times.
         |  --offset=<offset>                 Character offset to format, paired with --length.

--- a/core/src/test/kotlin/org/jetbrains/ktfmt/cli/MainTest.kt
+++ b/core/src/test/kotlin/org/jetbrains/ktfmt/cli/MainTest.kt
@@ -28,7 +28,9 @@ import org.jetbrains.ktfmt.testutil.assertContains
 import org.jetbrains.ktfmt.testutil.assertDoesNotContain
 import org.jetbrains.ktfmt.testutil.assertStartsWith
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -253,7 +255,7 @@ class MainTest {
   }
 
   @Test
-  fun `kotlinlang-style is passed to formatter (stdin)`() {
+  fun `kotlinlang-style is used for stdin without an EditorConfig path`() {
     val code =
         """
         |fun f() {
@@ -278,11 +280,57 @@ class MainTest {
         code.byteInputStream(),
         PrintStream(out),
         PrintStream(err),
-        arrayOf("--kotlinlang-style", "-"),
+        arrayOf("--kotlinlang-style", "--enable-editorconfig", "-"),
     )
         .run()
 
     assertEquals(formatted, out.toString(UTF_8))
+  }
+
+  @Test
+  fun `stdin-name is used for EditorConfig without reading the named file`() {
+    root
+        .resolve(".editorconfig")
+        .writeText(
+            """
+            root = true
+            [src/Foo.kt]
+            indent_size = 4
+            """
+                .trimIndent(),
+            UTF_8,
+        )
+    val namedFile = root.resolve("src/Foo.kt")
+    namedFile.parentFile.mkdirs()
+    val namedFileContent = byteArrayOf(0, 1, 2, 3)
+    namedFile.writeBytes(namedFileContent)
+    val code =
+        """
+        |fun test() {
+        |println("stdin")
+        |}
+        |"""
+            .trimMargin()
+
+    val exitCode = Main(
+        code.byteInputStream(),
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf("--enable-editorconfig", "--stdin-name=$namedFile", "-"),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals(
+        """
+        |fun test() {
+        |    println("stdin")
+        |}
+        |"""
+            .trimMargin(),
+        out.toString(UTF_8),
+    )
+    assertArrayEquals(namedFileContent, namedFile.readBytes())
   }
 
   @Test
@@ -622,6 +670,56 @@ class MainTest {
             .trimMargin(),
         out.toString(UTF_8),
     )
+  }
+
+  @Test
+  fun `--lines uses stdin-name for EditorConfig when the named file does not exist`() {
+    root
+        .resolve(".editorconfig")
+        .writeText(
+            """
+            root = true
+            [src/Generated.kt]
+            indent_size = 4
+            """
+                .trimIndent(),
+            UTF_8,
+        )
+    val namedFile = root.resolve("src/Generated.kt")
+    val code =
+        """
+        |fun test() {
+        |  val selected    =   2
+        |  val adjacent    =   3
+        |}
+        |"""
+            .trimMargin()
+
+    val exitCode = Main(
+        code.byteInputStream(),
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--enable-editorconfig",
+            "--stdin-name=$namedFile",
+            "--lines=2",
+            "-",
+        ),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals(
+        """
+        |fun test() {
+        |    val selected = 2
+        |  val adjacent    =   3
+        |}
+        |"""
+            .trimMargin(),
+        out.toString(UTF_8),
+    )
+    assertFalse(namedFile.exists())
   }
 
   @Test


### PR DESCRIPTION
This PR adds support for, when formatting source from stdin, use `--stdin-name` as the logical source path for `EditorConfig` lookup. This lets tools format virtual or staged source content while preserving ancestor `EditorConfig` settings and path-specific sections.