### PR TITLE
Small cleanup

### DIFF
--- a/core/api/ktfmt.api
+++ b/core/api/ktfmt.api
@@ -183,8 +183,11 @@ public final class org/jetbrains/ktfmt/format/KotlinInput : com/google/googlejav
 	public fun getkN ()I
 }
 
-public class org/jetbrains/ktfmt/format/KotlinInputAstVisitor : org/jetbrains/ktfmt/format/visitor/AbstractFormatterVisitor, org/jetbrains/ktfmt/format/visitor/FileFormatter, org/jetbrains/ktfmt/format/visitor/ListFormatter, org/jetbrains/ktfmt/format/visitor/TypeFormatter {
+public class org/jetbrains/ktfmt/format/KotlinInputAstVisitor : org/jetbrains/ktfmt/format/visitor/AbstractFormatterVisitor, org/jetbrains/ktfmt/format/visitor/ExpressionFormatter, org/jetbrains/ktfmt/format/visitor/FileFormatter, org/jetbrains/ktfmt/format/visitor/ListFormatter, org/jetbrains/ktfmt/format/visitor/TypeFormatter {
 	public fun <init> (Lorg/jetbrains/ktfmt/format/FormattingOptions;Lcom/google/googlejavaformat/OpsBuilder;)V
+	public fun formatChainedBlockLikeCall (Lorg/jetbrains/kotlin/psi/KtQualifiedExpression;Z)V
+	public fun formatChainedScopingFunction (Lorg/jetbrains/kotlin/psi/KtQualifiedExpression;Z)V
+	public fun formatLambdaOrScopingFunction (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;Z)V
 	public fun getBuilder ()Lcom/google/googlejavaformat/OpsBuilder;
 	public fun getExpressionBreakIndent ()Lcom/google/googlejavaformat/Indent$Const;
 	public fun getExpressionBreakNegativeIndent ()Lcom/google/googlejavaformat/Indent$Const;
@@ -439,6 +442,10 @@ public abstract class org/jetbrains/ktfmt/format/visitor/AbstractFormatterVisito
 	public fun visitWhileExpression (Lorg/jetbrains/kotlin/psi/KtWhileExpression;)V
 }
 
+public abstract interface class org/jetbrains/ktfmt/format/visitor/ExpressionFormatter : org/jetbrains/ktfmt/format/visitor/KotlinAstFormatter {
+	public fun formatInitializerExpression (Lorg/jetbrains/kotlin/psi/KtExpression;)V
+}
+
 public abstract interface class org/jetbrains/ktfmt/format/visitor/FileFormatter : org/jetbrains/ktfmt/format/visitor/KotlinAstFormatter {
 	public fun formatKtFile (Lorg/jetbrains/kotlin/psi/KtFile;)V
 	public fun formatKtScript (Lorg/jetbrains/kotlin/psi/KtScript;)V
@@ -459,6 +466,8 @@ public abstract interface class org/jetbrains/ktfmt/format/visitor/KotlinAstForm
 	public fun formatCallExpression (Lorg/jetbrains/kotlin/psi/KtCallExpression;)V
 	public fun formatCallableReferenceExpression (Lorg/jetbrains/kotlin/psi/KtCallableReferenceExpression;)V
 	public fun formatCatchSection (Lorg/jetbrains/kotlin/psi/KtCatchClause;)V
+	public abstract fun formatChainedBlockLikeCall (Lorg/jetbrains/kotlin/psi/KtQualifiedExpression;Z)V
+	public abstract fun formatChainedScopingFunction (Lorg/jetbrains/kotlin/psi/KtQualifiedExpression;Z)V
 	public fun formatClassBody (Lorg/jetbrains/kotlin/psi/KtClassBody;)V
 	public fun formatClassInitializer (Lorg/jetbrains/kotlin/psi/KtClassInitializer;)V
 	public fun formatClassLiteralExpression (Lorg/jetbrains/kotlin/psi/KtClassLiteralExpression;)V
@@ -483,12 +492,15 @@ public abstract interface class org/jetbrains/ktfmt/format/visitor/KotlinAstForm
 	public fun formatIfExpression (Lorg/jetbrains/kotlin/psi/KtIfExpression;)V
 	public fun formatImportDirective (Lorg/jetbrains/kotlin/psi/KtImportDirective;)V
 	public abstract fun formatImportList (Lorg/jetbrains/kotlin/psi/KtImportList;)V
+	public abstract fun formatInitializerExpression (Lorg/jetbrains/kotlin/psi/KtExpression;)V
 	public abstract fun formatIntersectionType (Lorg/jetbrains/kotlin/psi/KtIntersectionType;)V
 	public fun formatIsExpression (Lorg/jetbrains/kotlin/psi/KtIsExpression;)V
 	public abstract fun formatKtFile (Lorg/jetbrains/kotlin/psi/KtFile;)V
 	public abstract fun formatKtScript (Lorg/jetbrains/kotlin/psi/KtScript;)V
 	public fun formatLabeledExpression (Lorg/jetbrains/kotlin/psi/KtLabeledExpression;)V
 	public fun formatLambdaExpression (Lorg/jetbrains/kotlin/psi/KtLambdaExpression;)V
+	public abstract fun formatLambdaOrScopingFunction (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;Z)V
+	public static synthetic fun formatLambdaOrScopingFunction$default (Lorg/jetbrains/ktfmt/format/visitor/KotlinAstFormatter;Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;ZILjava/lang/Object;)V
 	public abstract fun formatModifierList (Lorg/jetbrains/kotlin/psi/KtModifierList;)V
 	public fun formatNamedFunction (Lorg/jetbrains/kotlin/psi/KtNamedFunction;)V
 	public abstract fun formatNullableType (Lorg/jetbrains/kotlin/psi/KtNullableType;)V
@@ -560,11 +572,14 @@ public final class org/jetbrains/ktfmt/format/visitor/OpsUtilsKt {
 }
 
 public final class org/jetbrains/ktfmt/format/visitor/PsiUtilsKt {
+	public static final fun chainedSelectorsHaveValueArguments (Lorg/jetbrains/kotlin/psi/KtExpression;)Z
 	public static final fun getCallExpression (Lorg/jetbrains/kotlin/psi/KtExpression;)Lorg/jetbrains/kotlin/psi/KtCallExpression;
+	public static final fun getChainParts (Lorg/jetbrains/kotlin/psi/KtExpression;)Ljava/util/List;
 	public static final fun getChainRoot (Lorg/jetbrains/kotlin/psi/KtExpression;)Lorg/jetbrains/kotlin/psi/KtExpression;
 	public static final fun getHasEmptyParenthesis (Lorg/jetbrains/kotlin/psi/KtParameterList;)Z
 	public static final fun getHasEmptyParenthesis (Lorg/jetbrains/kotlin/psi/KtValueArgumentList;)Z
 	public static final fun getHasLineBreakingCommentBefore (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;)Z
+	public static final fun getHasSourceNewlineInLambdaBody (Lorg/jetbrains/kotlin/psi/KtLambdaExpression;)Z
 	public static final fun getScopingLambda (Lorg/jetbrains/kotlin/psi/KtExpression;)Lorg/jetbrains/kotlin/psi/KtLambdaExpression;
 	public static final fun isBlockLikeArgument (Lorg/jetbrains/kotlin/psi/KtValueArgument;)Z
 	public static final fun isBlockLikeCall (Lorg/jetbrains/kotlin/psi/KtExpression;)Z
@@ -572,6 +587,7 @@ public final class org/jetbrains/ktfmt/format/visitor/PsiUtilsKt {
 	public static final fun isChainedScopingFunction (Lorg/jetbrains/kotlin/psi/KtExpression;)Z
 	public static final fun isLambda (Lorg/jetbrains/kotlin/psi/KtExpression;)Z
 	public static final fun isLambdaOrScopingFunction (Lorg/jetbrains/kotlin/psi/KtExpression;)Z
+	public static final fun isMultilineScopingFunction (Lorg/jetbrains/kotlin/psi/KtExpression;)Z
 	public static final fun isUnnamedLambda (Lorg/jetbrains/kotlin/psi/KtValueArgument;)Z
 }
 

--- a/core/api/ktfmt.api
+++ b/core/api/ktfmt.api
@@ -562,11 +562,17 @@ public final class org/jetbrains/ktfmt/format/visitor/OpsUtilsKt {
 public final class org/jetbrains/ktfmt/format/visitor/PsiUtilsKt {
 	public static final fun getCallExpression (Lorg/jetbrains/kotlin/psi/KtExpression;)Lorg/jetbrains/kotlin/psi/KtCallExpression;
 	public static final fun getChainRoot (Lorg/jetbrains/kotlin/psi/KtExpression;)Lorg/jetbrains/kotlin/psi/KtExpression;
-	public static final fun getHasEmptyParens (Lorg/jetbrains/kotlin/psi/KtValueArgumentList;)Z
-	public static final fun hasEmptyParens (Lorg/jetbrains/kotlin/psi/KtParameterList;)Z
+	public static final fun getHasEmptyParenthesis (Lorg/jetbrains/kotlin/psi/KtParameterList;)Z
+	public static final fun getHasEmptyParenthesis (Lorg/jetbrains/kotlin/psi/KtValueArgumentList;)Z
+	public static final fun getHasLineBreakingCommentBefore (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;)Z
+	public static final fun getScopingLambda (Lorg/jetbrains/kotlin/psi/KtExpression;)Lorg/jetbrains/kotlin/psi/KtLambdaExpression;
+	public static final fun isBlockLikeArgument (Lorg/jetbrains/kotlin/psi/KtValueArgument;)Z
 	public static final fun isBlockLikeCall (Lorg/jetbrains/kotlin/psi/KtExpression;)Z
 	public static final fun isChainedBlockLikeCall (Lorg/jetbrains/kotlin/psi/KtExpression;)Z
+	public static final fun isChainedScopingFunction (Lorg/jetbrains/kotlin/psi/KtExpression;)Z
 	public static final fun isLambda (Lorg/jetbrains/kotlin/psi/KtExpression;)Z
+	public static final fun isLambdaOrScopingFunction (Lorg/jetbrains/kotlin/psi/KtExpression;)Z
+	public static final fun isUnnamedLambda (Lorg/jetbrains/kotlin/psi/KtValueArgument;)Z
 }
 
 public abstract interface class org/jetbrains/ktfmt/format/visitor/TypeFormatter : org/jetbrains/ktfmt/format/visitor/KotlinAstFormatter {

--- a/core/api/ktfmt.api
+++ b/core/api/ktfmt.api
@@ -580,6 +580,7 @@ public abstract interface class org/jetbrains/ktfmt/format/visitor/TypeFormatter
 	public fun formatFunctionType (Lorg/jetbrains/kotlin/psi/KtFunctionType;)V
 	public fun formatIntersectionType (Lorg/jetbrains/kotlin/psi/KtIntersectionType;)V
 	public fun formatNullableType (Lorg/jetbrains/kotlin/psi/KtNullableType;)V
+	public fun formatType (Lorg/jetbrains/kotlin/psi/KtElement;Lorg/jetbrains/kotlin/psi/KtModifierList;Lorg/jetbrains/kotlin/psi/KtTypeElement;)V
 	public fun formatTypeConstraint (Lorg/jetbrains/kotlin/psi/KtTypeConstraint;)V
 	public fun formatTypeParameter (Lorg/jetbrains/kotlin/psi/KtTypeParameter;)V
 	public fun formatTypeProjection (Lorg/jetbrains/kotlin/psi/KtTypeProjection;)V

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/KotlinInputAstVisitor.kt
@@ -257,7 +257,7 @@ open class KotlinInputAstVisitor(
           if (parameterList != null) {
             formatCommaSeparatedList(
                 list = parameterList.parameters,
-                hasTrailingComma = parameterList.trailingComma != null,
+                forceMultiline = parameterList.trailingComma != null,
                 prefix = "(",
                 postfix = ")",
                 wrapInBlock = false,
@@ -1968,17 +1968,16 @@ open class KotlinInputAstVisitor(
    * expression (`a[3]`) and from within a qualified chain (`a[3].b)
    */
   private fun visitArrayAccessBrackets(expression: KtArrayAccessExpression) {
-    builder.block(ZERO) {
-      builder.token("[")
-      builder.breakOp(Doc.FillMode.UNIFIED, "", expressionBreakIndent)
-      builder.block(expressionBreakIndent) {
-        formatCommaSeparatedList(
-            expression.indexExpressions,
-            hasTrailingComma = expression.trailingComma != null,
-        )
-      }
+    builder.block(expressionBreakIndent) {
+      formatCommaSeparatedList(
+          expression.indexExpressions,
+          forceMultiline = expression.trailingComma != null,
+          wrapInBlock = true,
+          prefix = "[",
+          postfix = "]",
+          breakBeforePostfix = false,
+      )
     }
-    builder.token("]")
   }
 
   /** Example `val (a, b: Int) = Pair(1, 2)` or `val [a, b] = Pair(1, 2)` */
@@ -1992,17 +1991,15 @@ open class KotlinInputAstVisitor(
     val hasTrailingComma = destructuringDeclaration.trailingComma != null
     val openingDelimiter = destructuringDeclaration.lPar?.text ?: "("
     val closingDelimiter = destructuringDeclaration.rPar?.text ?: ")"
-    builder.block(ZERO) {
-      builder.token(openingDelimiter)
-      builder.breakOp(Doc.FillMode.UNIFIED, "", expressionBreakIndent)
-      builder.block(expressionBreakIndent) {
-        formatCommaSeparatedList(
-            destructuringDeclaration.entries,
-            hasTrailingComma,
-        )
-      }
+    builder.block(expressionBreakIndent) {
+      formatCommaSeparatedList(
+          destructuringDeclaration.entries,
+          forceMultiline = hasTrailingComma,
+          prefix = openingDelimiter,
+          postfix = closingDelimiter,
+          breakBeforePostfix = false,
+      )
     }
-    builder.token(closingDelimiter)
     val initializer = destructuringDeclaration.initializer
     if (initializer != null) {
       builder.space()
@@ -2219,7 +2216,7 @@ open class KotlinInputAstVisitor(
     builder.block(expressionBreakIndent) {
       formatCommaSeparatedList(
           expression.getInnerExpressions(),
-          hasTrailingComma = expression.trailingComma != null,
+          forceMultiline = expression.trailingComma != null,
           prefix = "[",
           postfix = "]",
           wrapInBlock = !options.manageTrailingCommas,

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/KotlinInputAstVisitor.kt
@@ -121,6 +121,7 @@ import org.jetbrains.ktfmt.format.visitor.ListFormatter
 import org.jetbrains.ktfmt.format.visitor.TypeFormatter
 import org.jetbrains.ktfmt.format.visitor.asIndent
 import org.jetbrains.ktfmt.format.visitor.block
+import org.jetbrains.ktfmt.format.visitor.chainParts
 import org.jetbrains.ktfmt.format.visitor.chainRoot
 import org.jetbrains.ktfmt.format.visitor.chainedSelectorsHaveValueArguments
 import org.jetbrains.ktfmt.format.visitor.fenceComments
@@ -424,7 +425,7 @@ open class KotlinInputAstVisitor(
    * part, emitting it to the [builder] while closing and opening groups.
    */
   private fun emitQualifiedExpression(expression: KtExpression) {
-    val parts = breakIntoParts(expression)
+    val parts = expression.chainParts
     // whether we want to make a lambda look like a block, this make Kotlin DSLs look as expected
     val useBlockLikeLambdaStyle = parts.last().isLambda && parts.count { it.isLambda } == 1
     val groupingInfos = computeGroupingInfo(parts, useBlockLikeLambdaStyle)
@@ -497,31 +498,6 @@ open class KotlinInputAstVisitor(
         }
       }
     }
-  }
-
-  /**
-   * Decomposes a qualified expression into parts, so `rainbow.red.orange.yellow` becomes `[rainbow,
-   * rainbow.red, rainbow.red.orange, rainbow.orange.yellow]`
-   */
-  private fun breakIntoParts(expression: KtExpression): List<KtExpression> {
-    val parts = ArrayDeque<KtExpression>()
-
-    // use an ArrayDeque and add elements to the beginning so the innermost expression comes first
-    // foo.bar.yay -> [yay, bar.yay, foo.bar.yay]
-
-    var node: KtExpression? = expression
-    while (node != null) {
-      parts.addFirst(node)
-      node =
-          when (node) {
-            is KtQualifiedExpression -> node.receiverExpression
-            is KtArrayAccessExpression -> node.arrayExpression
-            is KtPostfixExpression -> node.baseExpression
-            else -> null
-          }
-    }
-
-    return parts.toList()
   }
 
   /**
@@ -1255,7 +1231,7 @@ open class KotlinInputAstVisitor(
       expression: KtQualifiedExpression,
       emitLeadingBreak: Boolean,
   ) {
-    val parts = breakIntoParts(expression)
+    val parts = expression.chainParts
     if (emitLeadingBreak) {
       builder.space()
     }
@@ -1293,7 +1269,7 @@ open class KotlinInputAstVisitor(
       expression: KtQualifiedExpression,
       emitLeadingBreak: Boolean,
   ) {
-    val parts = breakIntoParts(expression)
+    val parts = expression.chainParts
     val root = parts[0]
     val forceBreakBeforeChain = root.isMultilineScopingFunction
 

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/KotlinInputAstVisitor.kt
@@ -31,7 +31,6 @@ import java.util.Optional
 import kotlin.jvm.optionals.getOrNull
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.com.intellij.psi.stubs.PsiFileStubImpl
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtAnnotatedExpression
@@ -116,20 +115,24 @@ import org.jetbrains.kotlin.psi.psiUtil.startsWithComment
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 import org.jetbrains.kotlin.psi.stubs.impl.KotlinPlaceHolderStubImpl
 import org.jetbrains.ktfmt.format.visitor.AbstractFormatterVisitor
+import org.jetbrains.ktfmt.format.visitor.ExpressionFormatter
 import org.jetbrains.ktfmt.format.visitor.FileFormatter
 import org.jetbrains.ktfmt.format.visitor.ListFormatter
 import org.jetbrains.ktfmt.format.visitor.TypeFormatter
 import org.jetbrains.ktfmt.format.visitor.asIndent
 import org.jetbrains.ktfmt.format.visitor.block
 import org.jetbrains.ktfmt.format.visitor.chainRoot
+import org.jetbrains.ktfmt.format.visitor.chainedSelectorsHaveValueArguments
 import org.jetbrains.ktfmt.format.visitor.fenceComments
 import org.jetbrains.ktfmt.format.visitor.hasEmptyParenthesis
 import org.jetbrains.ktfmt.format.visitor.hasLineBreakingCommentBefore
+import org.jetbrains.ktfmt.format.visitor.hasSourceNewlineInLambdaBody
 import org.jetbrains.ktfmt.format.visitor.isBlockLikeCall
 import org.jetbrains.ktfmt.format.visitor.isChainedBlockLikeCall
 import org.jetbrains.ktfmt.format.visitor.isChainedScopingFunction
 import org.jetbrains.ktfmt.format.visitor.isLambda
 import org.jetbrains.ktfmt.format.visitor.isLambdaOrScopingFunction
+import org.jetbrains.ktfmt.format.visitor.isMultilineScopingFunction
 import org.jetbrains.ktfmt.format.visitor.sync
 import org.jetbrains.ktfmt.format.visitor.token
 import org.jetbrains.ktfmt.util.CONTEXT_PARAMETER_LIST
@@ -139,7 +142,7 @@ import org.jetbrains.ktfmt.util.ownValOrVarKeywordText
 open class KotlinInputAstVisitor(
     override val options: FormattingOptions,
     override val builder: OpsBuilder,
-) : AbstractFormatterVisitor(), FileFormatter, TypeFormatter, ListFormatter {
+) : AbstractFormatterVisitor(), FileFormatter, TypeFormatter, ListFormatter, ExpressionFormatter {
 
   /** Standard indentation for a block */
   private val blockIndent: Indent.Const = options.blockIndent.asIndent
@@ -280,22 +283,7 @@ open class KotlinInputAstVisitor(
       } else if (bodyExpression != null) {
         builder.space()
         builder.block(ZERO) {
-          builder.token("=")
-          if (bodyExpression.isLambdaOrScopingFunction) {
-            visitLambdaOrScopingFunction(bodyExpression)
-          } else if (bodyExpression.isChainedScopingFunction) {
-            visitChainedScopingFunction(bodyExpression, emitLeadingBreak = true)
-          } else if (bodyExpression.isBlockLikeCall) {
-            builder.space()
-            visit(bodyExpression)
-          } else if (bodyExpression.isChainedBlockLikeCall) {
-            visitChainedBlockLikeCall(bodyExpression, emitLeadingBreak = true)
-          } else {
-            builder.block(expressionBreakIndent) {
-              builder.breakOp(Doc.FillMode.INDEPENDENT, " ", ZERO)
-              builder.block(ZERO) { visit(bodyExpression) }
-            }
-          }
+          formatInitializerExpression(bodyExpression)
         }
       }
       builder.guessToken(";")
@@ -406,8 +394,8 @@ open class KotlinInputAstVisitor(
         }
       }
       expression.isChainedScopingFunction &&
-          isMultilineScopingFunction(expression.chainRoot) &&
-          chainedSelectorsHaveNoValueArguments(expression) -> {
+          expression.chainRoot.isMultilineScopingFunction &&
+          !chainedSelectorsHaveValueArguments(expression) -> {
         visitChainedScopingFunction(expression, emitLeadingBreak = false)
       }
       expression.isChainedBlockLikeCall -> {
@@ -802,7 +790,7 @@ open class KotlinInputAstVisitor(
         builder.blankLineWanted(OpsBuilder.BlankLineWanted.NO)
 
         val shouldForceMultiline =
-            options.preserveLambdaBreaks && hasSourceNewlineInLambdaBody(lambdaExpression)
+            options.preserveLambdaBreaks && lambdaExpression.hasSourceNewlineInLambdaBody
 
         if (
             !shouldForceMultiline &&
@@ -1152,23 +1140,7 @@ open class KotlinInputAstVisitor(
         }
       } else if (initializer != null) {
         builder.space()
-        builder.token("=")
-        if (initializer.isLambdaOrScopingFunction) {
-          visitLambdaOrScopingFunction(initializer)
-        } else if (initializer.isChainedScopingFunction) {
-          visitChainedScopingFunction(initializer, emitLeadingBreak = true)
-        } else if (initializer.isBlockLikeCall) {
-          builder.space()
-          visit(initializer)
-        } else if (initializer.isChainedBlockLikeCall) {
-          visitChainedBlockLikeCall(initializer, emitLeadingBreak = true)
-        } else {
-          builder.breakOp(Doc.FillMode.UNIFIED, " ", expressionBreakIndent)
-          builder.block(expressionBreakIndent) {
-            builder.fenceComments()
-            visit(initializer)
-          }
-        }
+        formatInitializerExpression(initializer)
       }
     }
     // for example `field = value`, `private set`, or `get = 2 * field`
@@ -1238,23 +1210,7 @@ open class KotlinInputAstVisitor(
       val initializer = backingField.initializer
       if (initializer != null) {
         builder.space()
-        builder.token("=")
-        if (initializer.isLambdaOrScopingFunction) {
-          visitLambdaOrScopingFunction(initializer)
-        } else if (initializer.isChainedScopingFunction) {
-          visitChainedScopingFunction(initializer, emitLeadingBreak = true)
-        } else if (initializer.isBlockLikeCall) {
-          builder.space()
-          visit(initializer)
-        } else if (initializer.isChainedBlockLikeCall) {
-          visitChainedBlockLikeCall(initializer, emitLeadingBreak = true)
-        } else {
-          builder.breakOp(Doc.FillMode.UNIFIED, " ", expressionBreakIndent)
-          builder.block(expressionBreakIndent) {
-            builder.fenceComments()
-            visit(initializer)
-          }
-        }
+        formatInitializerExpression(initializer)
       }
     }
   }
@@ -1288,11 +1244,13 @@ open class KotlinInputAstVisitor(
     }
   }
 
-  /**
-   * Emit a `foo(\n ...,\n).bar().baz()` style chain whose innermost receiver is a block-like
-   * multiline call: render the receiver call normally (so its closing paren sits at the surrounding
-   * indent), then emit each `.selector` on its own line, indented by [expressionBreakIndent].
-   */
+  override fun formatChainedBlockLikeCall(
+      expression: KtQualifiedExpression,
+      emitLeadingBreak: Boolean,
+  ) {
+    visitChainedBlockLikeCall(expression, emitLeadingBreak)
+  }
+
   private fun visitChainedBlockLikeCall(
       expression: KtQualifiedExpression,
       emitLeadingBreak: Boolean,
@@ -1324,50 +1282,20 @@ open class KotlinInputAstVisitor(
     }
   }
 
-  /**
-   * Returns true when any chained selector after the innermost scoping-function receiver carries
-   * value arguments (i.e. `.foo(a)` or `.fold({ ... }, { ... })`). Used to decide formatting style
-   * for property initializers: value-arg chains stay on same line as `=`, while no-arg chains
-   * break.
-   */
-  private fun chainedSelectorsHaveValueArguments(expression: KtExpression): Boolean {
-    var current: KtExpression = expression
-    while (current is KtQualifiedExpression) {
-      val selector = current.selectorExpression
-      if (selector is KtCallExpression && !selector.valueArgumentList?.arguments.isNullOrEmpty()) {
-        return true
-      }
-      current = current.receiverExpression
-    }
-    return false
+  override fun formatChainedScopingFunction(
+      expression: KtQualifiedExpression,
+      emitLeadingBreak: Boolean,
+  ) {
+    visitChainedScopingFunction(expression, emitLeadingBreak)
   }
 
-  /**
-   * Returns true when every chained selector after the innermost scoping-function receiver carries
-   * no value arguments (i.e. only `.foo()` or `.foo { ... }` with a trailing lambda). Selectors
-   * that pass regular value arguments are excluded from special chained handling in qualified
-   * expressions, since those chains are better served by the general qualified-expression layout
-   * except in property initializer context where we handle them specially.
-   */
-  private fun chainedSelectorsHaveNoValueArguments(expression: KtExpression): Boolean {
-    return !chainedSelectorsHaveValueArguments(expression)
-  }
-
-  /**
-   * Emit `runnnnn { ... }.baz().qux()` style: render the innermost scoping-function receiver
-   * block-like (so the lambda braces sit at the surrounding indent), then emit each `.selector`
-   * after the closing brace as a chained continuation indented by [blockIndent].
-   *
-   * When the receiver lambda spans multiple lines in the source we force the chained selectors onto
-   * their own line; a single-line lambda stays joined to its chained call.
-   */
   private fun visitChainedScopingFunction(
       expression: KtQualifiedExpression,
       emitLeadingBreak: Boolean,
   ) {
     val parts = breakIntoParts(expression)
     val root = parts[0]
-    val forceBreakBeforeChain = isMultilineScopingFunction(root)
+    val forceBreakBeforeChain = root.isMultilineScopingFunction
 
     visitLambdaOrScopingFunction(root, emitLeadingBreak = emitLeadingBreak)
 
@@ -1396,43 +1324,10 @@ open class KotlinInputAstVisitor(
     }
   }
 
-  /**
-   * Returns true when [expression] is a scoping-function call whose lambda body has source-level
-   * newlines (i.e. spans multiple lines). Used to decide whether chained selectors after the
-   * lambda's closing brace must break onto a new line.
-   */
-  private fun isMultilineScopingFunction(expression: KtExpression): Boolean {
-    var carry: KtExpression? = expression
-    if (carry is KtQualifiedExpression && carry.receiverExpression is KtSimpleNameExpression) {
-      carry = carry.selectorExpression
-    }
-    if (carry is KtCallExpression) {
-      carry = carry.lambdaArguments.firstOrNull()?.getArgumentExpression()
-    }
-    if (carry is KtLabeledExpression) {
-      carry = carry.baseExpression
-    }
-    if (carry is KtLambdaExpression) {
-      return hasSourceNewlineInLambdaBody(carry)
-    }
-    return false
+  override fun formatLambdaOrScopingFunction(expr: PsiElement?, emitLeadingBreak: Boolean) {
+    visitLambdaOrScopingFunction(expr, emitLeadingBreak)
   }
 
-  /**
-   * Returns true if the source code contains a newline anywhere inside the body of
-   * [lambdaExpression] — that is, between the opening `{` and the closing `}` of the function
-   * literal. Used by [FormattingOptions.preserveLambdaBreaks] to keep user-authored multi-line
-   * lambdas multi-line.
-   */
-  private fun hasSourceNewlineInLambdaBody(lambdaExpression: KtLambdaExpression): Boolean {
-    val functionLiteral = lambdaExpression.functionLiteral
-    for (child in functionLiteral.node.children()) {
-      if (child.psi is PsiWhiteSpace && child.textContains('\n')) return true
-    }
-    return false
-  }
-
-  /** See [isLambdaOrScopingFunction] for examples. */
   private fun visitLambdaOrScopingFunction(expr: PsiElement?, emitLeadingBreak: Boolean = true) {
     val breakToExpr = genSym()
     val breakSpace = if (emitLeadingBreak) " " else ""

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/KotlinInputAstVisitor.kt
@@ -28,8 +28,6 @@ import com.google.googlejavaformat.OpsBuilder
 import com.google.googlejavaformat.Output.BreakTag
 import java.util.ArrayDeque
 import java.util.Optional
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.contract
 import kotlin.jvm.optionals.getOrNull
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
@@ -113,7 +111,6 @@ import org.jetbrains.kotlin.psi.KtWhenConditionWithExpression
 import org.jetbrains.kotlin.psi.KtWhenExpression
 import org.jetbrains.kotlin.psi.KtWhileExpression
 import org.jetbrains.kotlin.psi.psiUtil.children
-import org.jetbrains.kotlin.psi.psiUtil.getPrevSiblingIgnoringWhitespace
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import org.jetbrains.kotlin.psi.psiUtil.startsWithComment
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
@@ -124,13 +121,15 @@ import org.jetbrains.ktfmt.format.visitor.ListFormatter
 import org.jetbrains.ktfmt.format.visitor.TypeFormatter
 import org.jetbrains.ktfmt.format.visitor.asIndent
 import org.jetbrains.ktfmt.format.visitor.block
-import org.jetbrains.ktfmt.format.visitor.callExpression
 import org.jetbrains.ktfmt.format.visitor.chainRoot
 import org.jetbrains.ktfmt.format.visitor.fenceComments
-import org.jetbrains.ktfmt.format.visitor.hasEmptyParens
+import org.jetbrains.ktfmt.format.visitor.hasEmptyParenthesis
+import org.jetbrains.ktfmt.format.visitor.hasLineBreakingCommentBefore
 import org.jetbrains.ktfmt.format.visitor.isBlockLikeCall
 import org.jetbrains.ktfmt.format.visitor.isChainedBlockLikeCall
+import org.jetbrains.ktfmt.format.visitor.isChainedScopingFunction
 import org.jetbrains.ktfmt.format.visitor.isLambda
+import org.jetbrains.ktfmt.format.visitor.isLambdaOrScopingFunction
 import org.jetbrains.ktfmt.format.visitor.sync
 import org.jetbrains.ktfmt.format.visitor.token
 import org.jetbrains.ktfmt.util.CONTEXT_PARAMETER_LIST
@@ -244,7 +243,7 @@ open class KotlinInputAstVisitor(
         }
       }
 
-      if (parameterList != null && parameterList.hasEmptyParens()) {
+      if (parameterList != null && parameterList.hasEmptyParenthesis) {
         builder.block(ZERO) {
           builder.token("(")
           builder.token(")")
@@ -282,9 +281,9 @@ open class KotlinInputAstVisitor(
         builder.space()
         builder.block(ZERO) {
           builder.token("=")
-          if (isLambdaOrScopingFunction(bodyExpression)) {
+          if (bodyExpression.isLambdaOrScopingFunction) {
             visitLambdaOrScopingFunction(bodyExpression)
-          } else if (isChainedScopingFunction(bodyExpression)) {
+          } else if (bodyExpression.isChainedScopingFunction) {
             visitChainedScopingFunction(bodyExpression, emitLeadingBreak = true)
           } else if (bodyExpression.isBlockLikeCall) {
             builder.space()
@@ -406,7 +405,7 @@ open class KotlinInputAstVisitor(
           visit(expression.selectorExpression)
         }
       }
-      isChainedScopingFunction(expression) &&
+      expression.isChainedScopingFunction &&
           isMultilineScopingFunction(expression.chainRoot) &&
           chainedSelectorsHaveNoValueArguments(expression) -> {
         visitChainedScopingFunction(expression, emitLeadingBreak = false)
@@ -953,7 +952,7 @@ open class KotlinInputAstVisitor(
     builder.sync(expression)
     val op = expression.operationToken
 
-    if (KtTokens.ALL_ASSIGNMENTS.contains(op) && isLambdaOrScopingFunction(expression.right)) {
+    if (KtTokens.ALL_ASSIGNMENTS.contains(op) && expression.right.isLambdaOrScopingFunction) {
       // Assignments are statements in Kotlin; we don't have to worry about compound assignment.
       visit(expression.left)
       builder.space()
@@ -999,7 +998,7 @@ open class KotlinInputAstVisitor(
           }
           builder.token(leftExpression.operationReference.text)
           val fillMode =
-              if (hasLineBreakingCommentBefore(leftExpression.operationReference))
+              if (leftExpression.operationReference.hasLineBreakingCommentBefore)
                   Doc.FillMode.INDEPENDENT
               else Doc.FillMode.UNIFIED
           builder.breakOp(fillMode, " ", ZERO)
@@ -1008,28 +1007,6 @@ open class KotlinInputAstVisitor(
       visit(leftExpression.right)
     }
     builder.close()
-  }
-
-  /**
-   * Checks if a line-breaking comment precedes [element] in the PSI tree.
-   *
-   * Line comments (`//`) always force a break. Block comments (`/* */`) only count if they are on
-   * their own line (preceded by whitespace with a newline). Inline block comments like `x /*tag*/
-   * ||` do not force a break and should not trigger INDEPENDENT fill mode.
-   */
-  private fun hasLineBreakingCommentBefore(element: PsiElement): Boolean {
-    var prev = element.prevSibling
-    while (prev is PsiWhiteSpace) {
-      prev = prev.prevSibling
-    }
-    if (prev !is PsiComment) return false
-
-    // Line comments always force a line break
-    if (prev.text.startsWith("//")) return true
-
-    // Block comments force a break only if on their own line
-    val beforeComment = prev.prevSibling
-    return beforeComment is PsiWhiteSpace && beforeComment.text.contains('\n')
   }
 
   override fun visitPostfixExpression(expression: KtPostfixExpression) {
@@ -1156,10 +1133,10 @@ open class KotlinInputAstVisitor(
         builder.space()
         builder.token("by")
         val delegateExpr = delegate.expression
-        if (isLambdaOrScopingFunction(delegateExpr)) {
+        if (delegateExpr.isLambdaOrScopingFunction) {
           builder.space()
           visit(delegate)
-        } else if (delegateExpr != null && isChainedScopingFunction(delegateExpr)) {
+        } else if (delegateExpr != null && delegateExpr.isChainedScopingFunction) {
           visitChainedScopingFunction(delegateExpr, emitLeadingBreak = true)
         } else if (delegateExpr.isBlockLikeCall) {
           builder.space()
@@ -1176,9 +1153,9 @@ open class KotlinInputAstVisitor(
       } else if (initializer != null) {
         builder.space()
         builder.token("=")
-        if (isLambdaOrScopingFunction(initializer)) {
+        if (initializer.isLambdaOrScopingFunction) {
           visitLambdaOrScopingFunction(initializer)
-        } else if (isChainedScopingFunction(initializer)) {
+        } else if (initializer.isChainedScopingFunction) {
           visitChainedScopingFunction(initializer, emitLeadingBreak = true)
         } else if (initializer.isBlockLikeCall) {
           builder.space()
@@ -1262,9 +1239,9 @@ open class KotlinInputAstVisitor(
       if (initializer != null) {
         builder.space()
         builder.token("=")
-        if (isLambdaOrScopingFunction(initializer)) {
+        if (initializer.isLambdaOrScopingFunction) {
           visitLambdaOrScopingFunction(initializer)
-        } else if (isChainedScopingFunction(initializer)) {
+        } else if (initializer.isChainedScopingFunction) {
           visitChainedScopingFunction(initializer, emitLeadingBreak = true)
         } else if (initializer.isBlockLikeCall) {
           builder.space()
@@ -1309,67 +1286,6 @@ open class KotlinInputAstVisitor(
         return accessor.parameterList?.rightParenthesis
       }
     }
-  }
-
-  /**
-   * Returns whether an expression is a lambda or initializer expression in which case we will want
-   * to avoid indenting the lambda block
-   *
-   * Examples:
-   * 1. '... = { ... }' is a lambda expression
-   * 2. '... = Runnable { ... }' is considered a scoping function
-   * 3. '... = scope { ... }' '... = apply { ... }' is a scoping function
-   * 4. '... = scope.launch { ... }' is a dot-qualified scoping function
-   *
-   * but not:
-   * 1. '... = foo() { ... }' due to the empty parenthesis
-   * 2. '... = Runnable @Annotation { ... }' due to the annotation
-   */
-  private fun isLambdaOrScopingFunction(expression: KtExpression?): Boolean {
-    if (expression == null) return false
-    val prev = expression.getPrevSiblingIgnoringWhitespace()
-    if (prev is PsiComment && prev.text.startsWith("//")) {
-      return false // Leading line comments cause weird indentation; block comments are ok.
-    }
-
-    var carry = expression
-    if (carry is KtQualifiedExpression && carry.receiverExpression is KtSimpleNameExpression) {
-      carry = carry.selectorExpression
-    }
-    if (carry is KtCallExpression) {
-      if (
-          carry.valueArgumentList?.leftParenthesis == null &&
-              carry.lambdaArguments.isNotEmpty() &&
-              carry.typeArgumentList?.arguments.isNullOrEmpty()
-      ) {
-        carry = carry.lambdaArguments[0].getArgumentExpression()
-      } else {
-        return false
-      }
-    }
-    if (carry is KtLabeledExpression) {
-      carry = carry.baseExpression
-    }
-    if (carry is KtLambdaExpression) {
-      return true
-    }
-
-    return false
-  }
-
-  /**
-   * Returns true when [expression] is a chain whose innermost receiver is a scoping function call.
-   *
-   * For example, this matches `runnnnn { ... }.baz()` (innermost receiver `runnnnn { ... }` is a
-   * scoping function). It does not match a chain whose root is a plain identifier or a non-scoping
-   * call, since those don't have a block-like opener to anchor the chain against.
-   */
-  @OptIn(ExperimentalContracts::class)
-  private fun isChainedScopingFunction(expression: KtExpression): Boolean {
-    contract { returns(true) implies (expression is KtQualifiedExpression) }
-
-    if (expression !is KtQualifiedExpression) return false
-    return isLambdaOrScopingFunction(expression.chainRoot)
   }
 
   /**

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/ExpressionFormatter.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/ExpressionFormatter.kt
@@ -1,0 +1,26 @@
+package org.jetbrains.ktfmt.format.visitor
+
+import com.google.googlejavaformat.Doc
+import org.jetbrains.kotlin.psi.KtExpression
+
+interface ExpressionFormatter : KotlinAstFormatter {
+  override fun formatInitializerExpression(initializer: KtExpression) {
+    builder.token("=")
+    if (initializer.isLambdaOrScopingFunction) {
+      formatLambdaOrScopingFunction(initializer)
+    } else if (initializer.isChainedScopingFunction) {
+      formatChainedScopingFunction(initializer, emitLeadingBreak = true)
+    } else if (initializer.isBlockLikeCall) {
+      builder.space()
+      format(initializer)
+    } else if (initializer.isChainedBlockLikeCall) {
+      formatChainedBlockLikeCall(initializer, emitLeadingBreak = true)
+    } else {
+      builder.breakOp(Doc.FillMode.UNIFIED, " ", expressionBreakIndent)
+      builder.block(expressionBreakIndent) {
+        builder.fenceComments()
+        format(initializer)
+      }
+    }
+  }
+}

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/KotlinAstFormatter.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/KotlinAstFormatter.kt
@@ -32,6 +32,7 @@ import org.jetbrains.kotlin.psi.KtDestructuringDeclarationEntry
 import org.jetbrains.kotlin.psi.KtDoWhileExpression
 import org.jetbrains.kotlin.psi.KtDynamicType
 import org.jetbrains.kotlin.psi.KtEnumEntry
+import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFileAnnotationList
 import org.jetbrains.kotlin.psi.KtFinallySection
@@ -494,6 +495,38 @@ interface KotlinAstFormatter {
       breakAfterPrefix: Boolean = true,
       breakBeforePostfix: Boolean = options.manageTrailingCommas,
   ): BreakTag?
+
+  /**
+   * Format the right-hand side of an initializer expression, i.e. the expression after `=`
+   * (inclusively)
+   */
+  fun formatInitializerExpression(initializer: KtExpression)
+
+  /** See [isLambdaOrScopingFunction] for examples. */
+  fun formatLambdaOrScopingFunction(expr: PsiElement?, emitLeadingBreak: Boolean = true)
+
+  /**
+   * Emit a `foo(\n ...,\n).bar().baz()` style chain whose innermost receiver is a block-like
+   * multiline call: render the receiver call normally (so its closing paren sits at the surrounding
+   * indent), then emit each `.selector` on its own line, indented by [expressionBreakIndent].
+   */
+  fun formatChainedBlockLikeCall(
+      expression: KtQualifiedExpression,
+      emitLeadingBreak: Boolean,
+  )
+
+  /**
+   * Emit `runnnnn { ... }.baz().qux()` style: render the innermost scoping-function receiver
+   * block-like (so the lambda braces sit at the surrounding indent), then emit each `.selector`
+   * after the closing brace as a chained continuation indented by [blockIndent].
+   *
+   * When the receiver lambda spans multiple lines in the source we force the chained selectors onto
+   * their own line; a single-line lambda stays joined to its chained call.
+   */
+  fun formatChainedScopingFunction(
+      expression: KtQualifiedExpression,
+      emitLeadingBreak: Boolean,
+  )
 
   /**
    * markForPartialFormat is used to delineate the smallest areas of code that must be formatted

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/KotlinAstFormatter.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/KotlinAstFormatter.kt
@@ -434,7 +434,7 @@ interface KotlinAstFormatter {
    * ) {}
    * ```
    *
-   * @param hasTrailingComma if true, each element is placed on its own line (even if they could've
+   * @param forceMultiline if true, each element is placed on its own line (even if they could've
    *   fit in a single line) {}, and a trailing comma is emitted.
    *
    * Example:
@@ -443,16 +443,16 @@ interface KotlinAstFormatter {
    * b,
    * ```
    *
-   * @param wrapInBlock if true, place all the elements in a block. When there's no [leadingBreak],
-   *   this will be negatively indented. Note that the [prefix] and [postfix] aren't included in the
-   *   block.
-   * @param leadingBreak if true, break before the first element.
+   * @param wrapInBlock if true, place all the elements in a block. When there's no
+   *   [emitLeadingBreak], this will be negatively indented. Note that the [prefix] and [postfix]
+   *   aren't included in the block.
+   * @param emitLeadingBreak if true, break before the first element.
    * @param prefix if provided, emit this before the first element.
    * @param postfix if provided, emit this after the last element (or trailing comma) {}.
    * @param breakAfterPrefix if true, emit a break after [prefix], but before the start of the
    *   block.
    * @param breakBeforePostfix if true, place a break after the last element. Redundant when
-   *   [hasTrailingComma] is true.
+   *   [forceMultiline] is true.
    * @return a [BreakTag] which can tell you if a break was taken, but only when the list doesn't
    *   terminate in a negative closing indent.
    *
@@ -486,9 +486,9 @@ interface KotlinAstFormatter {
    */
   fun formatCommaSeparatedList(
       list: Iterable<PsiElement>,
-      hasTrailingComma: Boolean = false,
+      forceMultiline: Boolean = false,
       wrapInBlock: Boolean = true,
-      leadingBreak: Boolean = true,
+      emitLeadingBreak: Boolean = true,
       prefix: String? = null,
       postfix: String? = null,
       breakAfterPrefix: Boolean = true,

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/ListFormatter.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/ListFormatter.kt
@@ -10,7 +10,6 @@ import org.jetbrains.kotlin.lexer.KtModifierKeywordToken
 import org.jetbrains.kotlin.psi.KtContextReceiverList
 import org.jetbrains.kotlin.psi.KtFileAnnotationList
 import org.jetbrains.kotlin.psi.KtImportList
-import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtModifierList
 import org.jetbrains.kotlin.psi.KtParameterList
 import org.jetbrains.kotlin.psi.KtSuperTypeList
@@ -26,7 +25,7 @@ interface ListFormatter : KotlinAstFormatter {
     builder.sync(list)
     formatCommaSeparatedList(
         list.arguments,
-        hasTrailingComma = list.trailingComma != null,
+        forceMultiline = list.trailingComma != null,
         wrapInBlock = !options.manageTrailingCommas,
         prefix = "<",
         postfix = ">",
@@ -38,10 +37,10 @@ interface ListFormatter : KotlinAstFormatter {
     builder.block(expressionBreakIndent) {
       formatCommaSeparatedList(
           list.parameters,
-          hasTrailingComma = list.trailingComma != null,
+          forceMultiline = list.trailingComma != null,
+          wrapInBlock = !options.manageTrailingCommas,
           prefix = "<",
           postfix = ">",
-          wrapInBlock = !options.manageTrailingCommas,
       )
     }
   }
@@ -88,14 +87,7 @@ interface ListFormatter : KotlinAstFormatter {
       // A call without a trailing comma that is nonetheless forced onto multiple lines (because one
       // of its arguments is itself a block-like multiline call) is rendered "exploded", with its
       // closing parenthesis on its own line, just like a call with a trailing comma.
-      val contentForcesMultiline =
-          !hasTrailingComma &&
-              arguments.any { argument ->
-                val argumentExpression = argument.getArgumentExpression()
-                argumentExpression != null &&
-                    (argumentExpression.isBlockLikeCall ||
-                        argumentExpression.isChainedBlockLikeCall)
-              }
+      val contentForcesMultiline = !hasTrailingComma && arguments.any { it.isBlockLikeArgument }
       wrapInBlock = !options.manageTrailingCommas
       breakBeforePostfix =
           (options.manageTrailingCommas || contentForcesMultiline) && !hasEmptyParens
@@ -105,13 +97,13 @@ interface ListFormatter : KotlinAstFormatter {
 
     return formatCommaSeparatedList(
         arguments,
-        hasTrailingComma = hasTrailingComma,
+        forceMultiline = hasTrailingComma,
         wrapInBlock = wrapInBlock,
-        breakBeforePostfix = breakBeforePostfix,
-        leadingBreak = leadingBreak,
+        emitLeadingBreak = leadingBreak,
         prefix = "(",
         postfix = ")",
         breakAfterPrefix = breakAfterPrefix,
+        breakBeforePostfix = breakBeforePostfix,
     )
   }
 
@@ -165,7 +157,11 @@ interface ListFormatter : KotlinAstFormatter {
   }
 
   override fun formatParameterList(list: KtParameterList) {
-    formatCommaSeparatedList(list.parameters, list.trailingComma != null, wrapInBlock = false)
+    formatCommaSeparatedList(
+        list.parameters,
+        forceMultiline = list.trailingComma != null,
+        wrapInBlock = false,
+    )
   }
 
   override fun formatImportList(importList: KtImportList) {
@@ -185,16 +181,17 @@ interface ListFormatter : KotlinAstFormatter {
 
   override fun formatCommaSeparatedList(
       list: Iterable<PsiElement>,
-      hasTrailingComma: Boolean,
+      forceMultiline: Boolean,
       wrapInBlock: Boolean,
-      leadingBreak: Boolean,
+      emitLeadingBreak: Boolean,
       prefix: String?,
       postfix: String?,
       breakAfterPrefix: Boolean,
       breakBeforePostfix: Boolean,
   ): BreakTag? {
-    val breakAfterLastElement = hasTrailingComma || (postfix != null && breakBeforePostfix)
+    val breakAfterLastElement = forceMultiline || (postfix != null && breakBeforePostfix)
     val nameTag = if (breakAfterLastElement) null else BreakTag()
+    val breakType = if (forceMultiline) Doc.FillMode.FORCED else Doc.FillMode.UNIFIED
 
     if (prefix != null) {
       builder.token(prefix)
@@ -203,15 +200,14 @@ interface ListFormatter : KotlinAstFormatter {
       }
     }
 
-    val breakType = if (hasTrailingComma) Doc.FillMode.FORCED else Doc.FillMode.UNIFIED
     fun emitComma() {
       builder.token(",")
       builder.breakOp(breakType, " ", ZERO)
     }
 
-    val indent = if (leadingBreak) ZERO else expressionBreakNegativeIndent
+    val indent = if (emitLeadingBreak) ZERO else expressionBreakNegativeIndent
     builder.block(indent, isEnabled = wrapInBlock) {
-      if (leadingBreak) {
+      if (emitLeadingBreak) {
         builder.breakOp(breakType, "", ZERO)
       }
 
@@ -220,7 +216,7 @@ interface ListFormatter : KotlinAstFormatter {
         format(value)
       }
 
-      if (hasTrailingComma) {
+      if (forceMultiline) {
         emitComma()
       }
     }

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/ListFormatter.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/ListFormatter.kt
@@ -160,7 +160,8 @@ interface ListFormatter : KotlinAstFormatter {
     formatCommaSeparatedList(
         list.parameters,
         forceMultiline = list.trailingComma != null,
-        wrapInBlock = false,
+        prefix = "(",
+        postfix = ")",
     )
   }
 

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/ListFormatter.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/ListFormatter.kt
@@ -71,12 +71,9 @@ interface ListFormatter : KotlinAstFormatter {
     builder.sync(list)
 
     val arguments = list.arguments
-    val isSingleUnnamedLambda =
-        arguments.size == 1 &&
-            arguments.first().getArgumentExpression() is KtLambdaExpression &&
-            arguments.first().getArgumentName() == null
+    val isSingleUnnamedLambda = arguments.singleOrNull()?.isUnnamedLambda ?: false
     val hasTrailingComma = list.trailingComma != null
-    val hasEmptyParens = list.hasEmptyParens
+    val hasEmptyParens = list.hasEmptyParenthesis
 
     val wrapInBlock: Boolean
     val breakBeforePostfix: Boolean

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/PsiUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/PsiUtils.kt
@@ -21,17 +21,21 @@ import kotlin.contracts.contract
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.psi.KtArrayAccessExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtLabeledExpression
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtParameterList
+import org.jetbrains.kotlin.psi.KtPostfixExpression
 import org.jetbrains.kotlin.psi.KtQualifiedExpression
 import org.jetbrains.kotlin.psi.KtSimpleNameExpression
 import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.KtValueArgumentList
+import org.jetbrains.kotlin.psi.psiUtil.children
 import org.jetbrains.kotlin.psi.psiUtil.getNextSiblingIgnoringWhitespace
 import org.jetbrains.kotlin.psi.psiUtil.getPrevSiblingIgnoringWhitespace
+import org.jetbrains.ktfmt.format.FormattingOptions
 import org.jetbrains.ktfmt.format.KotlinInputAstVisitor
 
 /** Returns true if the expression represents an invocation that is also a lambda */
@@ -109,6 +113,26 @@ val KtExpression.chainRoot: KtExpression
     }
     return root
   }
+
+/**
+ * Decomposes a qualified expression into parts, so `rainbow.red.orange.yellow` becomes `[rainbow,
+ * rainbow.red, rainbow.red.orange, rainbow.orange.yellow]`
+ */
+val KtExpression.chainParts: List<KtExpression>
+  get() = buildList {
+    var node: KtExpression? = this@chainParts
+    while (node != null) {
+      add(node)
+      node =
+          when (node) {
+            is KtQualifiedExpression -> node.receiverExpression
+            is KtArrayAccessExpression -> node.arrayExpression
+            is KtPostfixExpression -> node.baseExpression
+            else -> null
+          }
+    }
+  }
+      .asReversed()
 
 /**
  * Checks if a line-breaking comment precedes [PsiElement] in the PSI tree.
@@ -200,4 +224,44 @@ val KtExpression.isChainedScopingFunction: Boolean
   get() {
     contract { returns(true) implies (this@isChainedScopingFunction is KtQualifiedExpression) }
     return this is KtQualifiedExpression && this.chainRoot.isLambdaOrScopingFunction
+  }
+
+/**
+ * Returns true when any chained selector after the innermost scoping-function receiver carries
+ * value arguments (i.e. `.foo(a)` or `.fold({ ... }, { ... })`). Used to decide formatting style
+ * for property initializers: value-arg chains stay on same line as `=`, while no-arg chains break.
+ */
+fun chainedSelectorsHaveValueArguments(expression: KtExpression): Boolean {
+  var current: KtExpression = expression
+  while (current is KtQualifiedExpression) {
+    val selector = current.selectorExpression
+    if (selector is KtCallExpression && !selector.valueArgumentList?.arguments.isNullOrEmpty()) {
+      return true
+    }
+    current = current.receiverExpression
+  }
+  return false
+}
+
+/**
+ * Returns true when [KtExpression] is a scoping-function call whose lambda body has source-level
+ * newlines (i.e. spans multiple lines). Used to decide whether chained selectors after the lambda's
+ * closing brace must break onto a new line.
+ */
+val KtExpression.isMultilineScopingFunction: Boolean
+  get() = scopingLambda?.hasSourceNewlineInLambdaBody ?: false
+
+/**
+ * Returns true if the source code contains a newline anywhere inside the body of
+ * [KtLambdaExpression] — that is, between the opening `{` and the closing `}` of the function
+ * literal. Used by [FormattingOptions.preserveLambdaBreaks] to keep user-authored multi-line
+ * lambdas multi-line.
+ */
+val KtLambdaExpression.hasSourceNewlineInLambdaBody: Boolean
+  get() {
+    val functionLiteral = this.functionLiteral
+    for (child in functionLiteral.node.children()) {
+      if (child.psi is PsiWhiteSpace && child.textContains('\n')) return true
+    }
+    return false
   }

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/PsiUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/PsiUtils.kt
@@ -19,32 +19,35 @@ package org.jetbrains.ktfmt.format.visitor
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtLabeledExpression
+import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtParameterList
 import org.jetbrains.kotlin.psi.KtQualifiedExpression
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
+import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.KtValueArgumentList
 import org.jetbrains.kotlin.psi.psiUtil.getNextSiblingIgnoringWhitespace
 import org.jetbrains.kotlin.psi.psiUtil.getPrevSiblingIgnoringWhitespace
+import org.jetbrains.ktfmt.format.KotlinInputAstVisitor
 
 /** Returns true if the expression represents an invocation that is also a lambda */
 val KtExpression.isLambda: Boolean
   get() = this.callExpression?.lambdaArguments?.isNotEmpty() ?: false
 
-/** Does this list have parens with only whitespace between them? */
-fun KtParameterList.hasEmptyParens(): Boolean {
-  val left = this.leftParenthesis ?: return false
-  val right = this.rightParenthesis ?: return false
-  return left.getNextSiblingIgnoringWhitespace() == right
-}
+/** @return true when a list has only empty parenthesis with only whitespace between them */
+val KtParameterList.hasEmptyParenthesis: Boolean
+  get() = onlyEmptyParenthesis(this.leftParenthesis, this.rightParenthesis)
 
-/** Does this list have parens with only whitespace between them? */
-val KtValueArgumentList.hasEmptyParens: Boolean
-  get() {
-    val left = this.leftParenthesis ?: return false
-    val right = this.rightParenthesis ?: return false
-    return left.getNextSiblingIgnoringWhitespace() == right
-  }
+/** @return true when a list has only empty parenthesis with only whitespace between them */
+val KtValueArgumentList.hasEmptyParenthesis: Boolean
+  get() = onlyEmptyParenthesis(this.leftParenthesis, this.rightParenthesis)
+
+private fun onlyEmptyParenthesis(left: PsiElement?, right: PsiElement?): Boolean =
+    left != null && right != null && left.getNextSiblingIgnoringWhitespace() == right
 
 /**
  * [KotlinInputAstVisitor.emitQualifiedExpression] formats call expressions that are either part of
@@ -55,9 +58,9 @@ val KtExpression.callExpression: KtCallExpression?
   get() = ((this as? KtQualifiedExpression)?.selectorExpression ?: this) as? KtCallExpression
 
 /**
- * Returns true when [this@isBlockLikeCall] is a call that is forced onto multiple lines regardless
- * of the line width, either because its value argument list has a trailing comma (e.g. `foo(\n 1,\n
- * 2,\n)`) or because one of its arguments is itself a block-like multiline call.
+ * @return true when [KtExpression] is a call that is forced onto multiple lines regardless of the
+ *   line width, either because its value argument list has a trailing comma (e.g. `foo(\n 1,\n
+ *   2,\n)`) or because one of its arguments is itself a block-like multiline call.
  *
  * Such calls are rendered "block-like": they stay on the same line as the preceding `=`/`by`
  * operator (instead of breaking and indenting after it), and any chained selectors break onto their
@@ -69,25 +72,27 @@ val KtExpression?.isBlockLikeCall: Boolean
     contract { returns(true) implies (this@isBlockLikeCall is KtCallExpression) }
 
     if (this == null) return false
-    val prev = this.getPrevSiblingIgnoringWhitespace()
-    if (prev is PsiComment) {
-      return false // Leading comments cause weird indentation; keep the default layout.
-    }
+    // Leading comments cause weird indentation; keep the default layout.
+    if (this.getPrevSiblingIgnoringWhitespace() is PsiComment) return false
 
     if (this !is KtCallExpression) return false
-    val valueArgumentList = this.valueArgumentList ?: return false
+
+    val valueArgumentList = valueArgumentList ?: return false
     return valueArgumentList.trailingComma != null ||
-        valueArgumentList.arguments.any { argument ->
-          val argumentExpression = argument.getArgumentExpression()
-          argumentExpression != null &&
-              (argumentExpression.isBlockLikeCall || argumentExpression.isChainedBlockLikeCall)
-        }
+        valueArgumentList.arguments.any { it.isBlockLikeArgument }
   }
 
-/**
- * Returns true when [this@isChainedBlockLikeCall] is a chain whose innermost receiver is a
- * [isBlockLikeCall].
- */
+val KtValueArgument.isBlockLikeArgument: Boolean
+  get() {
+    val argumentExpression = getArgumentExpression()
+    return argumentExpression != null &&
+        (argumentExpression.isBlockLikeCall || argumentExpression.isChainedBlockLikeCall)
+  }
+
+val KtValueArgument.isUnnamedLambda: Boolean
+  get() = getArgumentExpression() is KtLambdaExpression && getArgumentName() == null
+
+/** Returns true when [KtExpression] is a chain whose innermost receiver is a [isBlockLikeCall]. */
 @OptIn(ExperimentalContracts::class)
 val KtExpression.isChainedBlockLikeCall: Boolean
   get() {
@@ -95,7 +100,7 @@ val KtExpression.isChainedBlockLikeCall: Boolean
     return this is KtQualifiedExpression && this.chainRoot.isBlockLikeCall
   }
 
-/** Returns the innermost receiver of a (possibly nested) qualified [this@chainRoot]. */
+/** Returns the innermost receiver of a (possibly nested) qualified [KtExpression]. */
 val KtExpression.chainRoot: KtExpression
   get() {
     var root: KtExpression = this
@@ -103,4 +108,96 @@ val KtExpression.chainRoot: KtExpression
       root = root.receiverExpression
     }
     return root
+  }
+
+/**
+ * Checks if a line-breaking comment precedes [PsiElement] in the PSI tree.
+ *
+ * Line comments (`//`) always force a break. Block comments (`/* */`) only count if they are on
+ * their own line (preceded by whitespace with a newline). Inline block comments like `x /*tag*/ ||`
+ * do not force a break and should not trigger INDEPENDENT fill mode.
+ */
+val PsiElement.hasLineBreakingCommentBefore: Boolean
+  get() {
+    val comment = getPrevSiblingIgnoringWhiteSpace<PsiComment>() ?: return false
+
+    // Line comments always force a line break
+    if (comment.text.startsWith("//")) return true
+
+    // Block comments force a break only if on their own line
+    val beforeComment = comment.prevSibling
+    return beforeComment is PsiWhiteSpace && beforeComment.text.contains('\n')
+  }
+
+inline fun <reified T : PsiElement> PsiElement?.getPrevSiblingIgnoringWhiteSpace(): T? {
+  var prev = this?.prevSibling
+  while (prev is PsiWhiteSpace) {
+    prev = prev.prevSibling
+  }
+  return prev as? T
+}
+
+/**
+ * Returns an unwrapped lambda expression or scoping function of an expression
+ *
+ * Examples:
+ * 1. '... = { ... }' is a lambda expression
+ * 2. '... = Runnable { ... }' is considered a scoping function
+ * 3. '... = scope { ... }' '... = apply { ... }' is a scoping function
+ * 4. '... = scope.launch { ... }' is a dot-qualified scoping function
+ *
+ * but not:
+ * 1. '... = foo() { ... }' due to the empty parenthesis
+ * 2. '... = Runnable @Annotation { ... }' due to the annotation
+ */
+val KtExpression?.scopingLambda: KtLambdaExpression?
+  get() {
+    if (this == null) return null
+    var carry = this
+    if (carry is KtQualifiedExpression && carry.receiverExpression is KtSimpleNameExpression) {
+      carry = carry.selectorExpression
+    }
+    if (carry is KtCallExpression) {
+      if (
+          carry.valueArgumentList?.leftParenthesis == null &&
+              carry.lambdaArguments.isNotEmpty() &&
+              carry.typeArgumentList?.arguments.isNullOrEmpty()
+      ) {
+        carry = carry.lambdaArguments[0].getArgumentExpression()
+      } else {
+        return null
+      }
+    }
+    if (carry is KtLabeledExpression) {
+      carry = carry.baseExpression
+    }
+    return carry as? KtLambdaExpression
+  }
+
+/**
+ * Returns whether an expression is a lambda or an initializer expression, in which case we will
+ * want to avoid indenting the lambda block
+ */
+val KtExpression?.isLambdaOrScopingFunction: Boolean
+  get() {
+    if (this == null) return false
+    val comment = this.getPrevSiblingIgnoringWhiteSpace<PsiComment>()
+    // Leading line comments cause weird indentation; block comments are ok.
+    if (comment != null && comment.text.startsWith("//")) return false
+
+    return this.scopingLambda != null
+  }
+
+/**
+ * Returns true when [KtExpression] is a chain whose innermost receiver is a scoping function call.
+ *
+ * For example, this matches `runnnnn { ... }.baz()` (innermost receiver `runnnnn { ... }` is a
+ * scoping function). It does not match a chain whose root is a plain identifier or a non-scoping
+ * call, since those don't have a block-like opener to anchor the chain against.
+ */
+@OptIn(ExperimentalContracts::class)
+val KtExpression.isChainedScopingFunction: Boolean
+  get() {
+    contract { returns(true) implies (this@isChainedScopingFunction is KtQualifiedExpression) }
+    return this is KtQualifiedExpression && this.chainRoot.isLambdaOrScopingFunction
   }

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/TypeFormatter.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/TypeFormatter.kt
@@ -142,9 +142,9 @@ interface TypeFormatter : KotlinAstFormatter {
       if (parameterList != null) {
         formatCommaSeparatedList(
             parameterList.parameters,
+            forceMultiline = parameterList.trailingComma != null,
             prefix = "(",
             postfix = ")",
-            hasTrailingComma = parameterList.trailingComma != null,
         )
       }
     }

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/TypeFormatter.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/TypeFormatter.kt
@@ -4,11 +4,14 @@ package org.jetbrains.ktfmt.format.visitor
 
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtDynamicType
+import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFunctionType
 import org.jetbrains.kotlin.psi.KtIntersectionType
+import org.jetbrains.kotlin.psi.KtModifierList
 import org.jetbrains.kotlin.psi.KtNullableType
 import org.jetbrains.kotlin.psi.KtProjectionKind
 import org.jetbrains.kotlin.psi.KtTypeConstraint
+import org.jetbrains.kotlin.psi.KtTypeElement
 import org.jetbrains.kotlin.psi.KtTypeParameter
 import org.jetbrains.kotlin.psi.KtTypeProjection
 import org.jetbrains.kotlin.psi.KtTypeReference
@@ -17,23 +20,7 @@ import org.jetbrains.kotlin.psi.psiUtil.children
 
 interface TypeFormatter : KotlinAstFormatter {
   override fun formatTypeReference(type: KtTypeReference) {
-    builder.sync(type)
-    // Normally we'd visit the children nodes through accessors on 'typeReference', and  we wouldn't
-    // loop over children.
-    // But, in this case the modifier list can either be inside the parenthesis:
-    // ... (@Composable (x) -> Unit)
-    // or outside of them:
-    // ... @Composable ((x) -> Unit)
-    val modifierList = type.modifierList
-    val typeElement = type.typeElement
-    for (child in type.node.children()) {
-      when {
-        child.psi == modifierList -> format(modifierList)
-        child.psi == typeElement -> format(typeElement)
-        child.elementType == KtTokens.LPAR -> builder.token("(")
-        child.elementType == KtTokens.RPAR -> builder.token(")")
-      }
-    }
+    formatType(type, type.modifierList, type.typeElement)
   }
 
   override fun formatDynamicType(type: KtDynamicType) {
@@ -41,19 +28,7 @@ interface TypeFormatter : KotlinAstFormatter {
   }
 
   override fun formatNullableType(type: KtNullableType) {
-    builder.sync(type)
-
-    // Normally we wouldn't loop over children, but there can be multiple layers of parents.
-    val modifierList = type.modifierList
-    val innerType = type.innerType
-    for (child in type.node.children()) {
-      when {
-        child.psi == modifierList -> format(modifierList)
-        child.psi == innerType -> format(innerType)
-        child.elementType == KtTokens.LPAR -> builder.token("(")
-        child.elementType == KtTokens.RPAR -> builder.token(")")
-      }
-    }
+    formatType(type, type.modifierList, type.innerType)
     builder.token("?")
   }
 
@@ -137,20 +112,28 @@ interface TypeFormatter : KotlinAstFormatter {
       format(receiver)
       builder.token(".")
     }
-    builder.block(expressionBreakIndent) {
-      val parameterList = type.parameterList
-      if (parameterList != null) {
-        formatCommaSeparatedList(
-            parameterList.parameters,
-            forceMultiline = parameterList.trailingComma != null,
-            prefix = "(",
-            postfix = ")",
-        )
-      }
-    }
+    builder.block(expressionBreakIndent) { format(type.parameterList) }
     builder.space()
     builder.token("->")
     builder.space()
     builder.block(expressionBreakIndent) { format(type.returnTypeReference) }
+  }
+
+  fun formatType(type: KtElement, modifierList: KtModifierList?, typeElement: KtTypeElement?) {
+    builder.sync(type)
+    // Normally we'd visit the children nodes through accessors on 'typeReference', and  we wouldn't
+    // loop over children.
+    // But, in this case the modifier list can either be inside the parenthesis:
+    // ... (@Composable (x) -> Unit)
+    // or outside of them:
+    // ... @Composable ((x) -> Unit)
+    for (child in type.node.children()) {
+      when {
+        child.psi == modifierList -> format(modifierList)
+        child.psi == typeElement -> format(typeElement)
+        child.elementType == KtTokens.LPAR -> builder.token("(")
+        child.elementType == KtTokens.RPAR -> builder.token(")")
+      }
+    }
   }
 }


### PR DESCRIPTION
Some small cleanups that are not entirely connected with each other rather that just being general refactorings and simplifications done while analyzing the code

* Extract more utility methods from KIAV to PsuUtils
* Simplify some of the TypeFormatter methods
 * delegate TypeFormatter::formatFunctionType.parameterList formatting to dedicated method
* Use `formatCommaSeparatedList` in more cases where it can be used as a drop-in replacement. Other cases (e.g. `visitFunctionLikeExpression`) require more structural changes
* Extract a separate `formatInitializerExpression` method for formatting everything that comes after `=`