### PR TITLE
ktfmt offline playground

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/ktfmt/cli/ParsedArgs.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/cli/ParsedArgs.kt
@@ -129,6 +129,7 @@ data class ParsedArgs(
       var stdinName: String? = null
       var editorConfig = false
       var quiet = false
+      var useExperimentalEngine = false
       val lineRanges = TreeRangeSet.create<Int>()
       val offsets = mutableListOf<Int>()
       val lengths = mutableListOf<Int>()
@@ -158,6 +159,13 @@ data class ParsedArgs(
           arg == "--do-not-remove-unused-imports" -> removeUnusedImports = false
           arg == "--enable-editorconfig" -> editorConfig = true
           arg == "--quiet" -> quiet = true
+          arg == "--experimental-engine" -> {
+            // println, no ceremonies around streams, too experimental
+            System.err.println(
+                "You are using undocumented and unstable feature. We do not recommend doing so",
+            )
+            useExperimentalEngine = true
+          }
           arg.startsWith("--stdin-name=") ->
               stdinName =
                   parseKeyValueArg("--stdin-name", arg)
@@ -254,7 +262,10 @@ data class ParsedArgs(
 
       val parsedArgs = ParsedArgs(
           fileNames,
-          formattingOptions.copy(removeUnusedImports = removeUnusedImports),
+          formattingOptions.copy(
+              removeUnusedImports = removeUnusedImports,
+              experimentalEngine = useExperimentalEngine,
+          ),
           dryRun,
           setExitIfChanged,
           stdinName,

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,0 +1,13 @@
+# ktfmt playground
+
+```bash
+./playground/run.sh
+```
+Open <http://localhost:8000> and play with it.
+
+
+## Implementation details
+
+Under the hood, it runs `./gradlew :ktfmt:nativeCompile` and starts a trivial
+python server that serves formatting requests using the built native image.
+Close to zero latency, easy to experiment with a new formatter and compare

--- a/playground/index.html
+++ b/playground/index.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>ktfmt playground</title>
+    <style>
+        body {
+            margin: 2em;
+            font-family: sans-serif;
+        }
+
+        h1 {
+            font-size: 1.2em;
+        }
+
+        label {
+            display: block;
+            margin-bottom: 0.3em;
+        }
+
+        textarea,
+        pre {
+            width: 100%;
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0.5em;
+            border: 1px solid #ccc;
+            background: #fafafa;
+            font-family: monospace;
+            font-size: 13px;
+        }
+
+        textarea {
+            height: 40vh;
+        }
+
+        pre {
+            height: 40vh;
+            overflow: auto;
+        }
+
+        .outputs {
+            display: flex;
+            gap: 1em;
+            margin-top: 1em;
+        }
+
+        .outputs > div {
+            flex: 1;
+            min-width: 0;
+        }
+    </style>
+</head>
+<body>
+<h1>ktfmt playground</h1>
+
+<label for="input">Kotlin source</label>
+<textarea id="input" spellcheck="false" autofocus>
+        @Deprecated(
+    "Define a total timeout for the whole test instead of using dispatchTimeoutMs. " +
+        "Warning: the proposed replacement is not identical as it uses 'dispatchTimeoutMs' as the timeout for the whole test!",
+    ReplaceWith(
+        "this.runTest(timeout = dispatchTimeoutMs.milliseconds, testBody)",
+        "kotlin.time.Duration.Companion.milliseconds",
+    ),
+    DeprecationLevel.ERROR,
+) // Error since 1.11, warning since 1.7.0, was experimental in 1.6.x
+public fun TestScope.runTest(
+    dispatchTimeoutMs: Long,
+    testBody: suspend TestScope.() -> Unit,
+): TestResult =
+    asSpecificImplementation().let {}
+</textarea>
+
+<div class="outputs">
+    <div>
+        <label for="default-output">ktfmt</label>
+        <pre id="default-output"></pre>
+    </div>
+
+    <div>
+        <label for="experimental-output">ktfmt --experimental-engine</label>
+        <pre id="experimental-output"></pre>
+    </div>
+</div>
+
+<script>
+    (function () {
+        const input = document.getElementById("input");
+        const panes = {
+            default: document.getElementById("default-output"),
+            experimental: document.getElementById("experimental-output"),
+        };
+
+        const DEBOUNCE_MS = 250;
+        let timer = null;
+        let latestRequest = 0;
+
+        function paint(pane, result) {
+            pane.textContent = result.text;
+        }
+
+        async function format() {
+            const request = ++latestRequest;
+            try {
+                const response = await fetch("/format", {method: "POST", body: input.value});
+                if (!response.ok) throw new Error("HTTP " + response.status);
+                const data = await response.json();
+                if (request !== latestRequest) return;
+
+                paint(panes.default, data.default);
+                paint(panes.experimental, data.experimental);
+            } catch (error) {
+                if (request !== latestRequest) return;
+                const failure = {ok: false, text: "Cannot reach the ktfmt server: " + error.message};
+                paint(panes.default, failure);
+                paint(panes.experimental, failure);
+            }
+        }
+
+        input.addEventListener("input", function () {
+            clearTimeout(timer);
+            timer = setTimeout(format, DEBOUNCE_MS);
+        });
+
+        format();
+    })();
+</script>
+</body>
+</html>

--- a/playground/index.html
+++ b/playground/index.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>ktfmt playground</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
     <style>
         body {
             margin: 2em;
@@ -97,7 +99,7 @@ public fun TestScope.runTest(
         let latestRequest = 0;
 
         function paint(pane, result) {
-            pane.textContent = result.text;
+            pane.innerHTML = hljs.highlight(result.text, {language: "kotlin"}).value;
         }
 
         async function format() {

--- a/playground/run.sh
+++ b/playground/run.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#   ./playground/run.sh                   # build + run
+#   ./playground/run.sh /path/to/ktfmt    # run with predefinied binary
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_dir="$(cd "$script_dir/.." && pwd)"
+
+binary="${1:-}"
+if [[ -z "$binary" ]]; then
+  binary="$repo_dir/core/build/native/nativeCompile/ktfmt"
+  echo "Building the Native Image binary (this takes a few minutes on a cold build)..."
+  (cd "$repo_dir" && ./gradlew :ktfmt:nativeCompile)
+fi
+
+if [[ ! -x "$binary" ]]; then
+  echo "No executable ktfmt binary at: $binary" >&2
+  exit 1
+fi
+
+exec python3 "$script_dir/server.py" "$binary"

--- a/playground/server.py
+++ b/playground/server.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import subprocess
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PORT = 8000
+
+def do_format(binary, code, experimental):
+    args = [binary]
+    if experimental:
+        args.append("--experimental-engine")
+    args.append("-")
+    result = subprocess.run(
+        args,
+        input=code.encode("utf-8"),
+        capture_output=True,
+    )
+
+    if result.returncode != 0:
+        message = result.stderr.decode("utf-8", "replace").strip()
+        return False, message or f"ktfmt exited with code {result.returncode}"
+    return True, result.stdout.decode("utf-8", "replace")
+
+
+class PlaygroundHandler(SimpleHTTPRequestHandler):
+    binary = ""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=str(SCRIPT_DIR), **kwargs)
+
+    def do_POST(self):
+        if self.path != "/format":
+            self.send_error(404)
+            return
+
+        length = int(self.headers.get("Content-Length") or 0)
+        code = self.rfile.read(length).decode("utf-8", "replace")
+
+        default_ok, default_text = do_format(self.binary, code, experimental=False)
+        experimental_ok, experimental_text = do_format(self.binary, code, experimental=True)
+        payload = json.dumps(
+            {
+                "default": {"ok": default_ok, "text": default_text},
+                "experimental": {"ok": experimental_ok, "text": experimental_text},
+            }
+        ).encode("utf-8")
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, format, *args):
+        pass
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("binary")
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.binary) or not os.access(args.binary, os.X_OK):
+        parser.error(f"not an executable ktfmt binary: {args.binary}")
+
+    PlaygroundHandler.binary = args.binary
+    print(f"ktfmt playground on http://localhost:{PORT}  (binary: {args.binary})")
+    try:
+        HTTPServer(("127.0.0.1", PORT), PlaygroundHandler).serve_forever()
+    except KeyboardInterrupt:
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
`./playground/run.sh`

Something like this is very convenient for reviewing code style adjustments.
I've tried to review the actual _codestyle_ change in #674, but it's really tough without having an interactive playground.

I originally tried to build it with Wasm, but for K/W we have to fully migrate to the KMP parser, and for NI it doesn't work for a variety of reasons (e.g., https://github.com/oracle/graal/issues/14193). So maybe next time :)