### PR TITLE
Add --range-start and --range-end CLI options for range formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,12 @@ $ brew install ktfmt
 $ java -jar /path/to/ktfmt-<VERSION>-with-dependencies.jar [--kotlinlang-style | --google-style] [files...]
 ```
 
-The formatter can act on whole files, on limited lines (`--lines` or `--line`), or on specific
-offsets (`--offset` and `--length`). Line ranges look like `5` or `1:12,14`, may be used multiple
-times, and are 1-based. Offset ranges must provide matching `--offset` and `--length` pairs;
-`--length=0` formats the whole line containing the given `--offset`.
+The formatter can act on whole files, on limited lines (`--lines` or `--line`), on specific
+offsets (`--offset` and `--length`), or on character ranges (`--range-start` and `--range-end`).
+Line ranges look like `5` or `1:12,14`, may be used multiple times, and are 1-based. Offset ranges
+must provide matching `--offset` and `--length` pairs; `--length=0` formats the whole line containing
+the given `--offset`. Character ranges allow formatting between `--range-start` (0-based offset,
+inclusive, defaults to 0) and `--range-end` (0-based offset, exclusive, defaults to end of file).
 
 Partial formatting limits the core pretty-print replacements to the selected ranges. Whole-file
 cleanup passes, such as import cleanup and multiline string formatting, still run afterward to match

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/cli/Main.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/cli/Main.kt
@@ -202,5 +202,5 @@ class Main(
   }
 
   private fun ParsedArgs.isPartialFormat(): Boolean =
-      !lineRanges.isEmpty || !characterRanges.isEmpty
+      isPartialFormatting || !lineRanges.isEmpty || !characterRanges.isEmpty
 }

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/cli/ParsedArgs.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/cli/ParsedArgs.kt
@@ -47,6 +47,7 @@ data class ParsedArgs(
   internal val lineRanges: RangeSet<Int> = TreeRangeSet.create()
   /** Zero-indexed character ranges to format, using closed-open bounds. */
   internal val characterRanges: RangeSet<Int> = TreeRangeSet.create()
+  internal var isPartialFormatting: Boolean = false
 
   companion object {
 
@@ -96,6 +97,10 @@ data class ParsedArgs(
         |  --length=<length>                 Character length to format, paired with --offset.
         |                                        May be used multiple times. 0 formats the whole
         |                                        line containing the given --offset.
+        |  --range-start=<offset>            Format code starting at a given character offset
+        |                                        (inclusive). Defaults to 0.
+        |  --range-end=<offset>              Format code ending at a given character offset
+        |                                        (exclusive). Defaults to end of file.
         |  --set-exit-if-changed             Sets exit code to 1 if any input file was not
         |                                        formatted/touched
         |  --do-not-remove-unused-imports    Leaves all imports in place, even if not used
@@ -132,6 +137,8 @@ data class ParsedArgs(
       val lineRanges = TreeRangeSet.create<Int>()
       val offsets = mutableListOf<Int>()
       val lengths = mutableListOf<Int>()
+      var rangeStart: Int? = null
+      var rangeEnd: Int? = null
 
       if ("--help" in args || "-h" in args) return ParseResult.ShowMessage(HELP_TEXT)
       if ("--version" in args || "-v" in args) {
@@ -218,6 +225,48 @@ data class ParsedArgs(
                         ?: return ParseResult.Error("invalid integer value for $key: $value"),
                 )
               }
+          arg.startsWith("--range-start") ->
+              arg.split('=', limit = 2).let { argSplit ->
+                val key = argSplit.first()
+                if (key != "--range-start") {
+                  return ParseResult.Error("Unexpected option: $key")
+                }
+                val value =
+                    if (argSplit.size > 1) {
+                      argSplit.last()
+                    } else {
+                      nextValue()
+                          ?: return ParseResult.Error("required value was not provided for: $key")
+                    }
+                val parsedInt =
+                    value.toIntOrNull()
+                        ?: return ParseResult.Error("invalid integer value for $key: $value")
+                if (parsedInt < 0) {
+                  return ParseResult.Error("invalid integer value for $key: $value")
+                }
+                rangeStart = parsedInt
+              }
+          arg.startsWith("--range-end") ->
+              arg.split('=', limit = 2).let { argSplit ->
+                val key = argSplit.first()
+                if (key != "--range-end") {
+                  return ParseResult.Error("Unexpected option: $key")
+                }
+                val value =
+                    if (argSplit.size > 1) {
+                      argSplit.last()
+                    } else {
+                      nextValue()
+                          ?: return ParseResult.Error("required value was not provided for: $key")
+                    }
+                val parsedInt =
+                    value.toIntOrNull()
+                        ?: return ParseResult.Error("invalid integer value for $key: $value")
+                if (parsedInt < 0) {
+                  return ParseResult.Error("invalid integer value for $key: $value")
+                }
+                rangeEnd = parsedInt
+              }
           arg.startsWith("--") -> return ParseResult.Error("Unexpected option: $arg")
           arg.startsWith("@") -> return ParseResult.Error("Unexpected option: $arg")
           else -> fileNames.add(arg)
@@ -248,7 +297,27 @@ data class ParsedArgs(
         characterRanges.add(Range.closedOpen(offsets[index], offsets[index] + length))
       }
 
-      if ((!lineRanges.isEmpty || !characterRanges.isEmpty) && fileNames.size != 1) {
+      if (rangeStart != null || rangeEnd != null) {
+        val start = rangeStart ?: 0
+        val end = rangeEnd ?: Int.MAX_VALUE
+        if (start > end) {
+          return ParseResult.Error(
+              "--range-start ($start) cannot be greater than --range-end ($end)",
+          )
+        }
+        if (start < end) {
+          characterRanges.add(Range.closedOpen(start, end))
+        }
+      }
+
+      val hasPartialFormattingFlags =
+          !lineRanges.isEmpty ||
+              !characterRanges.isEmpty ||
+              rangeStart != null ||
+              rangeEnd != null ||
+              offsets.isNotEmpty()
+
+      if (hasPartialFormattingFlags && fileNames.size != 1) {
         return ParseResult.Error("partial formatting is only supported for a single file")
       }
 
@@ -261,6 +330,7 @@ data class ParsedArgs(
           editorConfig,
           quiet,
       )
+      parsedArgs.isPartialFormatting = hasPartialFormattingFlags
       parsedArgs.lineRanges.addAll(lineRanges)
       parsedArgs.characterRanges.addAll(characterRanges)
       return ParseResult.Ok(parsedArgs)

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/Formatter.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/Formatter.kt
@@ -241,7 +241,7 @@ object Formatter {
     if (characterRanges != null) {
       selectedCharacterRanges.addAll(adjustCharacterRangesForShebang(characterRanges, shebang))
     }
-    return selectedCharacterRanges
+    return selectedCharacterRanges.subRangeSet(Range.closedOpen(0, code.length))
   }
 
   private fun adjustLineRangesForShebang(
@@ -270,12 +270,14 @@ object Formatter {
     val adjusted = TreeRangeSet.create<Int>()
     val kotlinCodeStart = shebang.length + 1
     for (characterRange in characterRanges.subRangeSet(Range.atLeast(kotlinCodeStart)).asRanges()) {
-      adjusted.add(
-          Range.closedOpen(
-              characterRange.lowerEndpoint() - kotlinCodeStart,
-              characterRange.upperEndpoint() - kotlinCodeStart,
-          ),
-      )
+      val lower = maxOf(0, characterRange.lowerEndpoint() - kotlinCodeStart)
+      val upper =
+          if (characterRange.hasUpperBound()) {
+            maxOf(lower, characterRange.upperEndpoint() - kotlinCodeStart)
+          } else {
+            Int.MAX_VALUE
+          }
+      adjusted.add(Range.closedOpen(lower, upper))
     }
     return adjusted
   }

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/KotlinInput.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/KotlinInput.kt
@@ -78,12 +78,16 @@ class KotlinInput(private val text: String, file: KtFile) : Input() {
     val tokenRangeSet = TreeRangeSet.create<Int>()
     for (characterRange0 in characterRanges) {
       val characterRange = characterRange0.canonical(DiscreteDomain.integers())
-      tokenRangeSet.add(
-          characterRangeToTokenRange(
-              characterRange.lowerEndpoint(),
-              characterRange.upperEndpoint() - characterRange.lowerEndpoint(),
-          ),
-      )
+      if (characterRange.isEmpty) {
+        continue
+      }
+      val offset = characterRange.lowerEndpoint()
+      val length = characterRange.upperEndpoint() - offset
+      if (offset >= text.length || length <= 0) {
+        continue
+      }
+      val clampedLength = minOf(length, text.length - offset)
+      tokenRangeSet.add(characterRangeToTokenRange(offset, clampedLength))
     }
     return tokenRangeSet
   }

--- a/core/src/test/kotlin/org/jetbrains/ktfmt/cli/MainTest.kt
+++ b/core/src/test/kotlin/org/jetbrains/ktfmt/cli/MainTest.kt
@@ -830,6 +830,393 @@ class MainTest {
   }
 
   @Test
+  fun `--range-start and --range-end format the selected file statement`() {
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected    =   2
+        |  val adjacent    =   3
+        |}
+        |"""
+            .trimMargin()
+    val file = root.resolve("foo.kt")
+    file.writeText(code, UTF_8)
+
+    val startOffset = code.indexOf("val selected")
+    val endOffset = code.indexOf("val adjacent")
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--range-start=$startOffset",
+            "--range-end=$endOffset",
+            file.toString(),
+        ),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals(
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected = 2
+        |  val adjacent    =   3
+        |}
+        |"""
+            .trimMargin(),
+        file.readText(UTF_8),
+    )
+  }
+
+  @Test
+  fun `--range-start and --range-end format the selected stdin statement`() {
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected    =   2
+        |  val adjacent    =   3
+        |}
+        |"""
+            .trimMargin()
+
+    val startOffset = code.indexOf("val selected")
+    val endOffset = code.indexOf("val adjacent")
+    val exitCode = Main(
+        code.byteInputStream(),
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf("--range-start=$startOffset", "--range-end=$endOffset", "-"),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals(
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected = 2
+        |  val adjacent    =   3
+        |}
+        |"""
+            .trimMargin(),
+        out.toString(UTF_8),
+    )
+  }
+
+  @Test
+  fun `--range-start without --range-end formats to end of file`() {
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected    =   2
+        |  val adjacent    =   3
+        |}
+        |"""
+            .trimMargin()
+    val file = root.resolve("foo.kt")
+    file.writeText(code, UTF_8)
+
+    val startOffset = code.indexOf("fun test()")
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf("--range-start=$startOffset", file.toString()),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals(
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected = 2
+        |  val adjacent = 3
+        |}
+        |"""
+            .trimMargin(),
+        file.readText(UTF_8),
+    )
+  }
+
+  @Test
+  fun `--range-end without --range-start formats from start of file`() {
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected    =   2
+        |  val adjacent    =   3
+        |}
+        |"""
+            .trimMargin()
+    val file = root.resolve("foo.kt")
+    file.writeText(code, UTF_8)
+
+    val endOffset = code.indexOf("fun test()")
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf("--range-end=$endOffset", file.toString()),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals(
+        """
+        |fun untouched() = 1
+        |
+        |fun test() {
+        |  val selected    =   2
+        |  val adjacent    =   3
+        |}
+        |"""
+            .trimMargin(),
+        file.readText(UTF_8),
+    )
+  }
+
+  @Test
+  fun `--range-start and --range-end with --dry-run prints filename on changes`() {
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected    =   2
+        |}
+        |"""
+            .trimMargin()
+    val file = root.resolve("foo.kt")
+    file.writeText(code, UTF_8)
+
+    val startOffset = code.indexOf("val selected")
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--dry-run",
+            "--range-start=$startOffset",
+            "--range-end=${startOffset + 10}",
+            file.toString(),
+        ),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals(code, file.readText(UTF_8))
+    assertContains(out.toString(testCharset), file.toString())
+  }
+
+  @Test
+  fun `--range-start and --range-end with --set-exit-if-changed returns 1 on changes`() {
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected    =   2
+        |}
+        |"""
+            .trimMargin()
+    val file = root.resolve("foo.kt")
+    file.writeText(code, UTF_8)
+
+    val startOffset = code.indexOf("val selected")
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--set-exit-if-changed",
+            "--range-start=$startOffset",
+            "--range-end=${startOffset + 10}",
+            file.toString(),
+        ),
+    )
+        .run()
+
+    assertEquals(1, exitCode)
+  }
+
+  @Test
+  fun `--range-start and --range-end adjust properly for shebang`() {
+    val code =
+        """
+        |#!/usr/bin/env kotlin
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected    =   2
+        |  val adjacent    =   3
+        |}
+        |"""
+            .trimMargin()
+    val file = root.resolve("foo.kt")
+    file.writeText(code, UTF_8)
+
+    val startOffset = code.indexOf("val selected")
+    val endOffset = code.indexOf("val adjacent")
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--range-start=$startOffset",
+            "--range-end=$endOffset",
+            file.toString(),
+        ),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals(
+        """
+        |#!/usr/bin/env kotlin
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected = 2
+        |  val adjacent    =   3
+        |}
+        |"""
+            .trimMargin(),
+        file.readText(UTF_8),
+    )
+  }
+
+  @Test
+  fun `--range-start equal to --range-end leaves file untouched`() {
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected    =   2
+        |  val adjacent    =   3
+        |}
+        |"""
+            .trimMargin()
+    val file = root.resolve("foo.kt")
+    file.writeText(code, UTF_8)
+
+    val offset = code.indexOf("selected")
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--range-start=$offset",
+            "--range-end=$offset",
+            file.toString(),
+        ),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals(code, file.readText(UTF_8))
+  }
+
+  @Test
+  fun `--range-end beyond file length formats up to end of file without error`() {
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected    =   2
+        |}
+        |"""
+            .trimMargin()
+    val file = root.resolve("foo.kt")
+    file.writeText(code, UTF_8)
+
+    val startOffset = code.indexOf("fun test()")
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--range-start=$startOffset",
+            "--range-end=999999",
+            file.toString(),
+        ),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals(
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected = 2
+        |}
+        |"""
+            .trimMargin(),
+        file.readText(UTF_8),
+    )
+  }
+
+  @Test
+  fun `--range-start rejects directories that expand to multiple files`() {
+    val dir = root.resolve("dir")
+    dir.mkdirs()
+    dir.resolve("foo.kt").writeText("fun foo () = 1", UTF_8)
+    dir.resolve("bar.kt").writeText("fun bar () = 1", UTF_8)
+
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf("--range-start=0", dir.toString()),
+    )
+        .run()
+
+    assertEquals(1, exitCode)
+    assertContains(
+        err.toString(testCharset),
+        "partial formatting is only supported for a single file",
+    )
+  }
+
+  @Test
+  fun `--range-end rejects directories that expand to multiple files`() {
+    val dir = root.resolve("dir")
+    dir.mkdirs()
+    dir.resolve("foo.kt").writeText("fun foo () = 1", UTF_8)
+    dir.resolve("bar.kt").writeText("fun bar () = 1", UTF_8)
+
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf("--range-end=10", dir.toString()),
+    )
+        .run()
+
+    assertEquals(1, exitCode)
+    assertContains(
+        err.toString(testCharset),
+        "partial formatting is only supported for a single file",
+    )
+  }
+
+  @Test
   fun `--lines rejects directories that expand to multiple files`() {
     val dir = root.resolve("dir")
     dir.mkdirs()
@@ -844,6 +1231,691 @@ class MainTest {
     assertContains(
         err.toString(testCharset),
         "partial formatting is only supported for a single file",
+    )
+  }
+
+  @Test
+  fun `--offset rejects directories that expand to multiple files`() {
+    val dir = root.resolve("dir")
+    dir.mkdirs()
+    dir.resolve("foo.kt").writeText("fun foo () = 1", UTF_8)
+    dir.resolve("bar.kt").writeText("fun bar () = 1", UTF_8)
+
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf("--offset=0", "--length=5", dir.toString()),
+    )
+        .run()
+
+    assertEquals(1, exitCode)
+    assertContains(
+        err.toString(testCharset),
+        "partial formatting is only supported for a single file",
+    )
+  }
+
+  @Test
+  fun `--range-start accepts directory that expands to a single kt file`() {
+    val dir = root.resolve("dir")
+    dir.mkdirs()
+    val file = dir.resolve("single.kt")
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected    =   2
+        |}
+        |"""
+            .trimMargin()
+    file.writeText(code, UTF_8)
+
+    val startOffset = code.indexOf("val selected")
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf("--range-start=$startOffset", dir.toString()),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals(
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected = 2
+        |}
+        |"""
+            .trimMargin(),
+        file.readText(UTF_8),
+    )
+  }
+
+  @Test
+  fun `--range-start and --range-end with stdin and --dry-run prints stdin name when modified`() {
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected    =   2
+        |}
+        |"""
+            .trimMargin()
+    val startOffset = code.indexOf("val selected")
+    val exitCode = Main(
+        code.byteInputStream(UTF_8),
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--dry-run",
+            "--range-start=$startOffset",
+            "--range-end=${startOffset + 10}",
+            "-",
+        ),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals("<stdin>${System.lineSeparator()}", out.toString(testCharset))
+  }
+
+  @Test
+  fun `--range-start and --range-end with stdin and --dry-run prints nothing when unmodified`() {
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected = 2
+        |}
+        |"""
+            .trimMargin()
+    val startOffset = code.indexOf("val selected")
+    val exitCode = Main(
+        code.byteInputStream(UTF_8),
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--dry-run",
+            "--range-start=$startOffset",
+            "--range-end=${startOffset + 10}",
+            "-",
+        ),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals("", out.toString(testCharset))
+  }
+
+  @Test
+  fun `--range-start and --range-end with stdin, --stdin-name, and --dry-run prints custom name`() {
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected    =   2
+        |}
+        |"""
+            .trimMargin()
+    val startOffset = code.indexOf("val selected")
+    val exitCode = Main(
+        code.byteInputStream(UTF_8),
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--dry-run",
+            "--stdin-name=custom/Path.kt",
+            "--range-start=$startOffset",
+            "--range-end=${startOffset + 10}",
+            "-",
+        ),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals("custom/Path.kt${System.lineSeparator()}", out.toString(testCharset))
+  }
+
+  @Test
+  fun `--range-start and --range-end with stdin and --set-exit-if-changed returns 1 when modified`() {
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected    =   2
+        |}
+        |"""
+            .trimMargin()
+    val startOffset = code.indexOf("val selected")
+    val exitCode = Main(
+        code.byteInputStream(UTF_8),
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--set-exit-if-changed",
+            "--range-start=$startOffset",
+            "--range-end=${startOffset + 10}",
+            "-",
+        ),
+    )
+        .run()
+
+    assertEquals(1, exitCode)
+  }
+
+  @Test
+  fun `--range-start and --range-end with stdin and --set-exit-if-changed returns 0 when unmodified`() {
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected = 2
+        |}
+        |"""
+            .trimMargin()
+    val startOffset = code.indexOf("val selected")
+    val exitCode = Main(
+        code.byteInputStream(UTF_8),
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--set-exit-if-changed",
+            "--range-start=$startOffset",
+            "--range-end=${startOffset + 10}",
+            "-",
+        ),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+  }
+
+  @Test
+  fun `--range-start and --range-end with file and --dry-run prints nothing when unmodified`() {
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected = 2
+        |}
+        |"""
+            .trimMargin()
+    val file = root.resolve("foo.kt")
+    file.writeText(code, UTF_8)
+
+    val startOffset = code.indexOf("val selected")
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--dry-run",
+            "--range-start=$startOffset",
+            "--range-end=${startOffset + 10}",
+            file.toString(),
+        ),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals("", out.toString(testCharset))
+  }
+
+  @Test
+  fun `--range-start and --range-end with file and --set-exit-if-changed returns 0 when unmodified`() {
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected = 2
+        |}
+        |"""
+            .trimMargin()
+    val file = root.resolve("foo.kt")
+    file.writeText(code, UTF_8)
+
+    val startOffset = code.indexOf("val selected")
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--set-exit-if-changed",
+            "--range-start=$startOffset",
+            "--range-end=${startOffset + 10}",
+            file.toString(),
+        ),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+  }
+
+  @Test
+  fun `--range-start and --range-end with file, --dry-run, and --set-exit-if-changed returns 1 and prints filename`() {
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected    =   2
+        |}
+        |"""
+            .trimMargin()
+    val file = root.resolve("foo.kt")
+    file.writeText(code, UTF_8)
+
+    val startOffset = code.indexOf("val selected")
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--dry-run",
+            "--set-exit-if-changed",
+            "--range-start=$startOffset",
+            "--range-end=${startOffset + 10}",
+            file.toString(),
+        ),
+    )
+        .run()
+
+    assertEquals(1, exitCode)
+    assertEquals(code, file.readText(UTF_8))
+    assertContains(out.toString(testCharset), file.toString())
+  }
+
+  @Test
+  fun `--range-start and --range-end with stdin, --dry-run, and --set-exit-if-changed returns 1 and prints stdin name`() {
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected    =   2
+        |}
+        |"""
+            .trimMargin()
+    val startOffset = code.indexOf("val selected")
+    val exitCode = Main(
+        code.byteInputStream(UTF_8),
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--dry-run",
+            "--set-exit-if-changed",
+            "--range-start=$startOffset",
+            "--range-end=${startOffset + 10}",
+            "-",
+        ),
+    )
+        .run()
+
+    assertEquals(1, exitCode)
+    assertEquals("<stdin>${System.lineSeparator()}", out.toString(testCharset))
+  }
+
+  @Test
+  fun `--range-start and --range-end with stdin, --dry-run, and --set-exit-if-changed returns 0 and prints nothing when unchanged`() {
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected = 2
+        |}
+        |"""
+            .trimMargin()
+    val startOffset = code.indexOf("val selected")
+    val exitCode = Main(
+        code.byteInputStream(UTF_8),
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--dry-run",
+            "--set-exit-if-changed",
+            "--range-start=$startOffset",
+            "--range-end=${startOffset + 10}",
+            "-",
+        ),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals("", out.toString(testCharset))
+  }
+
+  @Test
+  fun `--range-start and --range-end with --quiet suppresses output but modifies file`() {
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected    =   2
+        |}
+        |"""
+            .trimMargin()
+    val file = root.resolve("foo.kt")
+    file.writeText(code, UTF_8)
+
+    val startOffset = code.indexOf("val selected")
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--quiet",
+            "--range-start=$startOffset",
+            "--range-end=${startOffset + 10}",
+            file.toString(),
+        ),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertDoesNotContain(err.toString(testCharset), "Done formatting")
+    assertEquals(
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected = 2
+        |}
+        |"""
+            .trimMargin(),
+        file.readText(UTF_8),
+    )
+  }
+
+  @Test
+  fun `--range-start and --range-end with --enable-editorconfig applies editorconfig formatting options`() {
+    val editorConfig = root.resolve(".editorconfig")
+    editorConfig.writeText(
+        """
+        |root = true
+        |[*.kt]
+        |indent_size = 4
+        |"""
+            .trimMargin(),
+        UTF_8,
+    )
+
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected    =   2
+        |}
+        |"""
+            .trimMargin()
+    val file = root.resolve("foo.kt")
+    file.writeText(code, UTF_8)
+
+    val startOffset = code.indexOf("val selected")
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--enable-editorconfig",
+            "--range-start=$startOffset",
+            "--range-end=${startOffset + 10}",
+            file.toString(),
+        ),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals(
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |    val selected = 2
+        |}
+        |"""
+            .trimMargin(),
+        file.readText(UTF_8),
+    )
+  }
+
+  @Test
+  fun `--range-start and --range-end preserves CRLF line endings in file`() {
+    val code = "fun untouched ( ) =   1\r\n\r\nfun test() {\r\n  val selected    =   2\r\n}\r\n"
+    val file = root.resolve("foo.kt")
+    file.writeText(code, UTF_8)
+
+    val startOffset = code.indexOf("val selected")
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--range-start=$startOffset",
+            "--range-end=${startOffset + 10}",
+            file.toString(),
+        ),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals(
+        "fun untouched ( ) =   1\r\n\r\nfun test() {\r\n  val selected = 2\r\n}\r\n",
+        file.readText(UTF_8),
+    )
+  }
+
+  @Test
+  fun `--range-start and --range-end preserves CRLF line endings with shebang`() {
+    val code =
+        "#!/usr/bin/env kotlin\r\nfun untouched ( ) =   1\r\n\r\nfun test() {\r\n  val selected    =   2\r\n}\r\n"
+    val file = root.resolve("foo.kt")
+    file.writeText(code, UTF_8)
+
+    val startOffset = code.indexOf("val selected")
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--range-start=$startOffset",
+            "--range-end=${startOffset + 10}",
+            file.toString(),
+        ),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals(
+        "#!/usr/bin/env kotlin\r\nfun untouched ( ) =   1\r\n\r\nfun test() {\r\n  val selected = 2\r\n}\r\n",
+        file.readText(UTF_8),
+    )
+  }
+
+  @Test
+  fun `--range-start and --range-end ignores UTF-8 BOM in file`() {
+    val code = "\uFEFFfun untouched ( ) =   1\n\nfun test() {\n  val selected    =   2\n}\n"
+    val file = root.resolve("foo.kt")
+    file.writeText(code, UTF_8)
+
+    val startOffset = code.indexOf("val selected")
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--range-start=$startOffset",
+            "--range-end=${startOffset + 10}",
+            file.toString(),
+        ),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals(
+        "fun untouched ( ) =   1\n\nfun test() {\n  val selected = 2\n}\n",
+        file.readText(UTF_8),
+    )
+  }
+
+  @Test
+  fun `--range-start and --range-end reports syntax error with filename and position`() {
+    val code = "fun test( {\n"
+    val file = root.resolve("broken.kt")
+    file.writeText(code, UTF_8)
+
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf("--range-start=0", "--range-end=5", file.toString()),
+    )
+        .run()
+
+    assertEquals(1, exitCode)
+    assertContains(err.toString(testCharset), "broken.kt:1:")
+  }
+
+  @Test
+  fun `@argfile containing range-start and range-end options formats selected statement`() {
+    val file = root.resolve("foo.kt")
+    val code =
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected    =   2
+        |}
+        |"""
+            .trimMargin()
+    file.writeText(code, UTF_8)
+
+    val startOffset = code.indexOf("val selected")
+    val endOffset = startOffset + 15
+    val argfile = root.resolve("argfile")
+    argfile.writeText(
+        "--range-start=$startOffset\n--range-end=$endOffset\n${file.canonicalPath}\n",
+        UTF_8,
+    )
+
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf("@" + argfile.canonicalPath),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals(
+        """
+        |fun untouched ( ) =   1
+        |
+        |fun test() {
+        |  val selected = 2
+        |}
+        |"""
+            .trimMargin(),
+        file.readText(UTF_8),
+    )
+  }
+
+  @Test
+  fun `Multiple disjoint --offset and --length ranges format only targeted regions`() {
+    val code =
+        """
+        |fun test1() {
+        |  val first    =   1
+        |  val untouched    =   2
+        |  val second    =   3
+        |}
+        |"""
+            .trimMargin()
+    val file = root.resolve("foo.kt")
+    file.writeText(code, UTF_8)
+
+    val firstOffset = code.indexOf("val first")
+    val secondOffset = code.indexOf("val second")
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--offset=$firstOffset",
+            "--length=10",
+            "--offset=$secondOffset",
+            "--length=10",
+            file.toString(),
+        ),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals(
+        """
+        |fun test1() {
+        |  val first = 1
+        |  val untouched    =   2
+        |  val second = 3
+        |}
+        |"""
+            .trimMargin(),
+        file.readText(UTF_8),
+    )
+  }
+
+  @Test
+  fun `Combined --range-start, --range-end, and --lines options format union of selections`() {
+    val code =
+        """
+        |fun test() {
+        |  val first    =   1
+        |  val untouched    =   2
+        |  val third    =   3
+        |}
+        |"""
+            .trimMargin()
+    val file = root.resolve("foo.kt")
+    file.writeText(code, UTF_8)
+
+    val thirdOffset = code.indexOf("val third")
+    val exitCode = Main(
+        emptyInput,
+        PrintStream(out),
+        PrintStream(err),
+        arrayOf(
+            "--lines=2",
+            "--range-start=$thirdOffset",
+            "--range-end=${thirdOffset + 10}",
+            file.toString(),
+        ),
+    )
+        .run()
+
+    assertEquals(0, exitCode)
+    assertEquals(
+        """
+        |fun test() {
+        |  val first = 1
+        |  val untouched    =   2
+        |  val third = 3
+        |}
+        |"""
+            .trimMargin(),
+        file.readText(UTF_8),
     )
   }
 }

--- a/core/src/test/kotlin/org/jetbrains/ktfmt/cli/ParsedArgsTest.kt
+++ b/core/src/test/kotlin/org/jetbrains/ktfmt/cli/ParsedArgsTest.kt
@@ -219,8 +219,124 @@ class ParsedArgsTest {
   }
 
   @Test
+  fun `parseOptions recognizes --range-start and --range-end`() {
+    val parsed = assertSucceeds(parseOptions("--range-start=10", "--range-end=20", "foo.kt"))
+    assertEquals(ranges(Range.closedOpen(10, 20)), parsed.characterRanges)
+    assertTrue(parsed.isPartialFormatting)
+  }
+
+  @Test
+  fun `parseOptions recognizes --range-start without --range-end`() {
+    val parsed = assertSucceeds(parseOptions("--range-start=10", "foo.kt"))
+    assertEquals(ranges(Range.closedOpen(10, Int.MAX_VALUE)), parsed.characterRanges)
+    assertTrue(parsed.isPartialFormatting)
+  }
+
+  @Test
+  fun `parseOptions recognizes --range-end without --range-start`() {
+    val parsed = assertSucceeds(parseOptions("--range-end=20", "foo.kt"))
+    assertEquals(ranges(Range.closedOpen(0, 20)), parsed.characterRanges)
+    assertTrue(parsed.isPartialFormatting)
+  }
+
+  @Test
+  fun `parseOptions recognizes --range-start and --range-end with space separated value`() {
+    val parsed = assertSucceeds(parseOptions("--range-start", "15", "--range-end", "25", "foo.kt"))
+    assertEquals(ranges(Range.closedOpen(15, 25)), parsed.characterRanges)
+    assertTrue(parsed.isPartialFormatting)
+  }
+
+  @Test
+  fun `parseOptions accepts --range-start equal to --range-end`() {
+    val parsed = assertSucceeds(parseOptions("--range-start=10", "--range-end=10", "foo.kt"))
+    assertTrue(parsed.characterRanges.isEmpty)
+    assertTrue(parsed.isPartialFormatting)
+  }
+
+  @Test
+  fun `parseOptions rejects --range-start without value`() {
+    val parseResult = parseOptions("--range-start")
+    assertEquals(
+        ParseResult.Error("required value was not provided for: --range-start"),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions rejects --range-end without value`() {
+    val parseResult = parseOptions("--range-end")
+    assertEquals(
+        ParseResult.Error("required value was not provided for: --range-end"),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions rejects invalid --range-start`() {
+    val parseResult = parseOptions("--range-start=not-a-number", "foo.kt")
+    assertEquals(
+        ParseResult.Error("invalid integer value for --range-start: not-a-number"),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions rejects invalid --range-end`() {
+    val parseResult = parseOptions("--range-end=not-a-number", "foo.kt")
+    assertEquals(
+        ParseResult.Error("invalid integer value for --range-end: not-a-number"),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions rejects negative --range-start`() {
+    val parseResult = parseOptions("--range-start=-5", "foo.kt")
+    assertEquals(
+        ParseResult.Error("invalid integer value for --range-start: -5"),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions rejects negative --range-end`() {
+    val parseResult = parseOptions("--range-end=-5", "foo.kt")
+    assertEquals(
+        ParseResult.Error("invalid integer value for --range-end: -5"),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions rejects --range-start greater than --range-end`() {
+    val parseResult = parseOptions("--range-start=25", "--range-end=10", "foo.kt")
+    assertEquals(
+        ParseResult.Error("--range-start (25) cannot be greater than --range-end (10)"),
+        parseResult,
+    )
+  }
+
+  @Test
   fun `parseOptions rejects --offset with multiple files`() {
     val parseResult = parseOptions("--offset=1", "--length=1", "foo.kt", "bar.kt")
+    assertEquals(
+        ParseResult.Error("partial formatting is only supported for a single file"),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions rejects --range-start with multiple files`() {
+    val parseResult = parseOptions("--range-start=10", "foo.kt", "bar.kt")
+    assertEquals(
+        ParseResult.Error("partial formatting is only supported for a single file"),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions rejects --range-end with multiple files`() {
+    val parseResult = parseOptions("--range-end=10", "foo.kt", "bar.kt")
     assertEquals(
         ParseResult.Error("partial formatting is only supported for a single file"),
         parseResult,
@@ -347,6 +463,212 @@ class ParsedArgsTest {
   fun `error when parsing multiple args and one is unknown`() {
     val testResult = parseOptions("@unknown", "--google-style", "File.kt")
     assertEquals(ParseResult.Error("Unexpected option: @unknown"), testResult)
+  }
+
+  @Test
+  fun `parseOptions rejects --length without value`() {
+    val parseResult = parseOptions("--length")
+    assertEquals(
+        ParseResult.Error("required value was not provided for: --length"),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions rejects invalid --length`() {
+    val parseResult = parseOptions("--offset=0", "--length=not-a-number", "foo.kt")
+    assertEquals(
+        ParseResult.Error("invalid integer value for --length: not-a-number"),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions rejects unexpected option starting with --offset`() {
+    val parseResult = parseOptions("--offset-start=10", "foo.kt")
+    assertEquals(
+        ParseResult.Error("Unexpected option: --offset-start"),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions rejects unexpected option starting with --length`() {
+    val parseResult = parseOptions("--length-extra=10", "foo.kt")
+    assertEquals(
+        ParseResult.Error("Unexpected option: --length-extra"),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions rejects unexpected option starting with --range-start`() {
+    val parseResult = parseOptions("--range-starter=10", "foo.kt")
+    assertEquals(
+        ParseResult.Error("Unexpected option: --range-starter"),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions rejects unexpected option starting with --range-end`() {
+    val parseResult = parseOptions("--range-ender=10", "foo.kt")
+    assertEquals(
+        ParseResult.Error("Unexpected option: --range-ender"),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions rejects unexpected option starting with --line`() {
+    val parseResult = parseOptions("--line-extra=10", "foo.kt")
+    assertEquals(
+        ParseResult.Error("Unexpected option: --line-extra"),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions rejects space separated --offset without value at end of args`() {
+    val parseResult = parseOptions("--offset")
+    assertEquals(
+        ParseResult.Error("required value was not provided for: --offset"),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions rejects space separated --length without value at end of args`() {
+    val parseResult = parseOptions("--offset", "10", "--length")
+    assertEquals(
+        ParseResult.Error("required value was not provided for: --length"),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions rejects empty value for --range-start`() {
+    val parseResult = parseOptions("--range-start=", "foo.kt")
+    assertEquals(
+        ParseResult.Error("invalid integer value for --range-start: "),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions rejects empty value for --range-end`() {
+    val parseResult = parseOptions("--range-end=", "foo.kt")
+    assertEquals(
+        ParseResult.Error("invalid integer value for --range-end: "),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions handles repeated --range-start and --range-end (last flag wins)`() {
+    val parsed = assertSucceeds(
+        parseOptions(
+            "--range-start=5",
+            "--range-start=15",
+            "--range-end=50",
+            "--range-end=25",
+            "foo.kt",
+        ),
+    )
+    assertEquals(ranges(Range.closedOpen(15, 25)), parsed.characterRanges)
+    assertTrue(parsed.isPartialFormatting)
+  }
+
+  @Test
+  fun `parseOptions combines --range-start and --range-end with --offset and --length`() {
+    val parsed = assertSucceeds(
+        parseOptions(
+            "--range-start=10",
+            "--range-end=20",
+            "--offset=30",
+            "--length=5",
+            "foo.kt",
+        ),
+    )
+    assertEquals(
+        ranges(
+            Range.closedOpen(10, 20),
+            Range.closedOpen(30, 35),
+        ),
+        parsed.characterRanges,
+    )
+    assertTrue(parsed.isPartialFormatting)
+  }
+
+  @Test
+  fun `parseOptions combines --range-start and --range-end with --lines`() {
+    val parsed = assertSucceeds(
+        parseOptions(
+            "--range-start=10",
+            "--range-end=20",
+            "--lines=1:3",
+            "foo.kt",
+        ),
+    )
+    assertEquals(ranges(Range.closedOpen(10, 20)), parsed.characterRanges)
+    assertEquals(ranges(Range.closedOpen(0, 3)), parsed.lineRanges)
+    assertTrue(parsed.isPartialFormatting)
+  }
+
+  @Test
+  fun `parseOptions rejects --range-start with no files provided`() {
+    val parseResult = parseOptions("--range-start=10")
+    assertEquals(
+        ParseResult.Error("partial formatting is only supported for a single file"),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions rejects --range-end with no files provided`() {
+    val parseResult = parseOptions("--range-end=10")
+    assertEquals(
+        ParseResult.Error("partial formatting is only supported for a single file"),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `parseOptions rejects --range-start equal to --range-end with multiple files`() {
+    val parseResult = parseOptions("--range-start=10", "--range-end=10", "foo.kt", "bar.kt")
+    assertEquals(
+        ParseResult.Error("partial formatting is only supported for a single file"),
+        parseResult,
+    )
+  }
+
+  @Test
+  fun `processArgs parses --range-start and --range-end from argfile`() {
+    val file = root.resolve("argfile")
+    file.writeText("--range-start=10\n--range-end=20\nfoo.kt\n")
+
+    val result = ParsedArgs.processArgs(arrayOf("@" + file.canonicalPath))
+    assertInstanceOf(ParseResult.Ok::class.java, result)
+
+    val parsed = (result as ParseResult.Ok).parsedValue
+    assertEquals(ranges(Range.closedOpen(10, 20)), parsed.characterRanges)
+    assertEquals(listOf("foo.kt"), parsed.fileNames)
+    assertTrue(parsed.isPartialFormatting)
+  }
+
+  @Test
+  fun `processArgs parses --lines, --offset, and --length from argfile`() {
+    val file = root.resolve("argfile")
+    file.writeText("--lines=1:5\n--offset=12\n--length=4\nfoo.kt\n")
+
+    val result = ParsedArgs.processArgs(arrayOf("@" + file.canonicalPath))
+    assertInstanceOf(ParseResult.Ok::class.java, result)
+
+    val parsed = (result as ParseResult.Ok).parsedValue
+    assertEquals(ranges(Range.closedOpen(0, 5)), parsed.lineRanges)
+    assertEquals(ranges(Range.closedOpen(12, 16)), parsed.characterRanges)
+    assertEquals(listOf("foo.kt"), parsed.fileNames)
+    assertTrue(parsed.isPartialFormatting)
   }
 
   private fun parseOptions(vararg options: String): ParseResult = ParsedArgs.parseOptions(options)

--- a/core/src/test/kotlin/org/jetbrains/ktfmt/format/FormatTest.kt
+++ b/core/src/test/kotlin/org/jetbrains/ktfmt/format/FormatTest.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.ktfmt.format
 
+import com.google.common.collect.Range
+import com.google.common.collect.TreeRangeSet
 import org.jetbrains.ktfmt.testutil.FormatterTestFactory
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -15,5 +17,229 @@ class FormatTest : FormatterTestFactory() {
       val reformatted = Formatter.format(DEFAULT_CASE_FORMAT, code)
       assertEquals(code, reformatted)
     }
+  }
+
+  @Test
+  fun `format with lineRanges and characterRanges both null performs full formatting`() {
+    val code = "fun foo ( ) = 1\nfun bar ( ) = 2\n"
+    val formatted =
+        Formatter.format(DEFAULT_CASE_FORMAT, code, lineRanges = null, characterRanges = null)
+    assertEquals("fun foo() = 1\n\nfun bar() = 2\n", formatted)
+  }
+
+  @Test
+  fun `format with lineRanges non-null and characterRanges null formats only specified lines`() {
+    val code = "fun foo ( ) = 1\nfun bar ( ) = 2\n"
+    val lineRanges = TreeRangeSet.create<Int>().apply { add(Range.closedOpen(0, 1)) }
+    val formatted =
+        Formatter.format(DEFAULT_CASE_FORMAT, code, lineRanges = lineRanges, characterRanges = null)
+    assertEquals("fun foo() = 1\n\nfun bar ( ) = 2\n", formatted)
+  }
+
+  @Test
+  fun `format with lineRanges null and characterRanges non-null formats only specified character ranges`() {
+    val code = "fun foo ( ) = 1\nfun bar ( ) = 2\n"
+    val barOffset = code.indexOf("fun bar")
+    val characterRanges =
+        TreeRangeSet.create<Int>().apply {
+          add(Range.closedOpen(barOffset, barOffset + 15))
+        }
+    val formatted =
+        Formatter.format(
+            DEFAULT_CASE_FORMAT,
+            code,
+            lineRanges = null,
+            characterRanges = characterRanges,
+        )
+    assertEquals("fun foo ( ) = 1\n\nfun bar() = 2\n", formatted)
+  }
+
+  @Test
+  fun `format with both lineRanges and characterRanges non-null formats union of ranges`() {
+    val code = "fun foo ( ) = 1\nfun bar ( ) = 2\nfun baz ( ) = 3\n"
+    val lineRanges = TreeRangeSet.create<Int>().apply { add(Range.closedOpen(0, 1)) }
+    val bazOffset = code.indexOf("fun baz")
+    val characterRanges =
+        TreeRangeSet.create<Int>().apply {
+          add(Range.closedOpen(bazOffset, bazOffset + 15))
+        }
+    val formatted =
+        Formatter.format(
+            DEFAULT_CASE_FORMAT,
+            code,
+            lineRanges = lineRanges,
+            characterRanges = characterRanges,
+        )
+    assertEquals("fun foo() = 1\n\nfun bar ( ) = 2\n\nfun baz() = 3\n", formatted)
+  }
+
+  @Test
+  fun `format with empty lineRanges and characterRanges leaves code untouched but cleans imports and multiline strings`() {
+    val code =
+        """
+        |val s = ""${'"'}
+        |        hello
+        |        ""${'"'}.trimIndent()
+        |fun foo ( ) = 1
+        |"""
+            .trimMargin()
+    val emptyRanges = TreeRangeSet.create<Int>()
+    val formatted =
+        Formatter.format(
+            DEFAULT_CASE_FORMAT,
+            code,
+            lineRanges = emptyRanges,
+            characterRanges = emptyRanges,
+        )
+    assertEquals(
+        """
+        |val s = ""${'"'}
+        |hello
+        |""${'"'}
+        |    .trimIndent()
+        |fun foo ( ) = 1
+        |"""
+            .trimMargin(),
+        formatted,
+    )
+  }
+
+  @Test
+  fun `format with range entirely within shebang leaves kotlin code untouched and preserves shebang`() {
+    val code = "#!/usr/bin/env kotlin\nfun foo ( ) = 1\n"
+    val characterRanges = TreeRangeSet.create<Int>().apply { add(Range.closedOpen(0, 10)) }
+    val formatted = Formatter.format(DEFAULT_CASE_FORMAT, code, characterRanges = characterRanges)
+    assertEquals(code, formatted)
+  }
+
+  @Test
+  fun `format with range crossing shebang boundary formats only kotlin code portion`() {
+    val code = "#!/usr/bin/env kotlin\nfun foo ( ) = 1\nfun bar ( ) = 2\n"
+    val characterRanges = TreeRangeSet.create<Int>().apply { add(Range.closedOpen(10, 35)) }
+    val formatted = Formatter.format(DEFAULT_CASE_FORMAT, code, characterRanges = characterRanges)
+    assertEquals("#!/usr/bin/env kotlin\nfun foo() = 1\n\nfun bar ( ) = 2\n", formatted)
+  }
+
+  @Test
+  fun `format with range after shebang adjusts offsets and formats target code`() {
+    val code = "#!/usr/bin/env kotlin\nfun foo ( ) = 1\nfun bar ( ) = 2\n"
+    val barOffset = code.indexOf("fun bar")
+    val characterRanges =
+        TreeRangeSet.create<Int>().apply {
+          add(Range.closedOpen(barOffset, barOffset + 15))
+        }
+    val formatted = Formatter.format(DEFAULT_CASE_FORMAT, code, characterRanges = characterRanges)
+    assertEquals("#!/usr/bin/env kotlin\nfun foo ( ) = 1\n\nfun bar() = 2\n", formatted)
+  }
+
+  @Test
+  fun `format with line range selecting line 0 on code with shebang leaves kotlin code untouched`() {
+    val code = "#!/usr/bin/env kotlin\nfun foo ( ) = 1\n"
+    val lineRanges = TreeRangeSet.create<Int>().apply { add(Range.closedOpen(0, 1)) }
+    val formatted = Formatter.format(DEFAULT_CASE_FORMAT, code, lineRanges = lineRanges)
+    assertEquals(code, formatted)
+  }
+
+  @Test
+  fun `format with line range spanning line 0 and line 1 adjusts line index for shebang`() {
+    val code = "#!/usr/bin/env kotlin\nfun foo ( ) = 1\nfun bar ( ) = 2\n"
+    val lineRanges = TreeRangeSet.create<Int>().apply { add(Range.closedOpen(0, 2)) }
+    val formatted = Formatter.format(DEFAULT_CASE_FORMAT, code, lineRanges = lineRanges)
+    assertEquals("#!/usr/bin/env kotlin\nfun foo() = 1\n\nfun bar ( ) = 2\n", formatted)
+  }
+
+  @Test
+  fun `format with empty string and character range returns empty string`() {
+    val characterRanges = TreeRangeSet.create<Int>().apply { add(Range.closedOpen(0, 10)) }
+    val formatted = Formatter.format(DEFAULT_CASE_FORMAT, "", characterRanges = characterRanges)
+    assertEquals("", formatted)
+  }
+
+  @Test
+  fun `format with shebang only and character range returns shebang`() {
+    val code = "#!/bin/sh\n"
+    val characterRanges = TreeRangeSet.create<Int>().apply { add(Range.closedOpen(0, 10)) }
+    val formatted = Formatter.format(DEFAULT_CASE_FORMAT, code, characterRanges = characterRanges)
+    assertEquals(code, formatted)
+  }
+
+  @Test
+  fun `format with shebang and CRLF line endings preserves shebang and CRLF`() {
+    val code = "#!/usr/bin/env kotlin\r\nfun foo ( ) = 1\r\nfun bar ( ) = 2\r\n"
+    val fooOffset = code.indexOf("fun foo")
+    val characterRanges =
+        TreeRangeSet.create<Int>().apply {
+          add(Range.closedOpen(fooOffset, fooOffset + 15))
+        }
+    val formatted = Formatter.format(DEFAULT_CASE_FORMAT, code, characterRanges = characterRanges)
+    assertEquals("#!/usr/bin/env kotlin\r\nfun foo() = 1\r\n\r\nfun bar ( ) = 2\r\n", formatted)
+  }
+
+  @Test
+  fun `format with character range preserves CRLF and CR line endings`() {
+    for (ending in listOf("\r\n", "\r")) {
+      val code = "fun foo ( ) = 1${ending}fun bar ( ) = 2${ending}"
+      val fooOffset = code.indexOf("fun foo")
+      val characterRanges =
+          TreeRangeSet.create<Int>().apply {
+            add(Range.closedOpen(fooOffset, fooOffset + 15))
+          }
+      val formatted = Formatter.format(DEFAULT_CASE_FORMAT, code, characterRanges = characterRanges)
+      assertEquals("fun foo() = 1${ending}${ending}fun bar ( ) = 2${ending}", formatted)
+    }
+  }
+
+  @Test
+  fun `format overloads format code and handle unused imports option`() {
+    val codeWithUnused = "import com.unused.Class\n\nfun foo ( ) = 1\n"
+    assertEquals("fun foo() = 1\n", Formatter.format(codeWithUnused))
+    assertEquals(
+        "import com.unused.Class\n\nfun foo() = 1\n",
+        Formatter.format(codeWithUnused, removeUnusedImports = false),
+    )
+  }
+
+  @Test
+  fun `format with out of bounds line ranges leaves code untouched`() {
+    val code = "fun foo ( ) = 1\n"
+    val lineRanges = TreeRangeSet.create<Int>().apply { add(Range.closedOpen(100, 200)) }
+    val formatted = Formatter.format(DEFAULT_CASE_FORMAT, code, lineRanges = lineRanges)
+    assertEquals(code, formatted)
+  }
+
+  @Test
+  fun `format with out of bounds character ranges leaves code untouched`() {
+    val code = "fun foo ( ) = 1\n"
+    val characterRanges = TreeRangeSet.create<Int>().apply { add(Range.closedOpen(500, 600)) }
+    val formatted = Formatter.format(DEFAULT_CASE_FORMAT, code, characterRanges = characterRanges)
+    assertEquals(code, formatted)
+  }
+
+  @Test
+  fun `format handles statement formatting inside a block`() {
+    val code =
+        """
+        |fun test() {
+        |  val untouched    =   1
+        |  val selected     =   2
+        |}
+        |"""
+            .trimMargin()
+    val selectedOffset = code.indexOf("val selected")
+    val characterRanges =
+        TreeRangeSet.create<Int>().apply {
+          add(Range.closedOpen(selectedOffset, selectedOffset + 15))
+        }
+    val formatted = Formatter.format(Formatter.META_FORMAT, code, characterRanges = characterRanges)
+    assertEquals(
+        """
+        |fun test() {
+        |  val untouched    =   1
+        |  val selected = 2
+        |}
+        |"""
+            .trimMargin(),
+        formatted,
+    )
   }
 }

--- a/core/src/test/kotlin/org/jetbrains/ktfmt/format/KotlinInputTest.kt
+++ b/core/src/test/kotlin/org/jetbrains/ktfmt/format/KotlinInputTest.kt
@@ -16,8 +16,16 @@
 
 package org.jetbrains.ktfmt.format
 
+import com.google.common.collect.Range
+import com.google.common.collect.TreeRangeSet
+import com.google.googlejavaformat.java.FormatterException
+import org.jetbrains.ktfmt.testutil.assertContains
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class KotlinInputTest {
   @Test
@@ -26,5 +34,175 @@ class KotlinInputTest {
     val input = KotlinInput(code, Parser.parse(code))
     assertEquals(listOf("class", "F", "{", "}", ""), input.getTokens().map { it.tok.text })
     assertEquals(listOf("/** foo */", " "), input.getTokens()[0].toksBefore.map { it.text })
+  }
+
+  @Test
+  fun `characterRangesToTokenRanges ignores empty and out-of-bounds ranges`() {
+    val code = "class F {}"
+    val input = KotlinInput(code, Parser.parse(code))
+    val tokenRanges =
+        input.characterRangesToTokenRanges(
+            listOf(
+                Range.closedOpen(2, 2),
+                Range.closedOpen(100, 200),
+                Range.closedOpen(0, 5),
+            ),
+        )
+    assertEquals(
+        TreeRangeSet.create<Int>().apply {
+          add(Range.closedOpen(0, 1))
+        },
+        tokenRanges,
+    )
+  }
+
+  @Test
+  fun `characterRangesToTokenRanges returns empty range set for empty input`() {
+    val code = "fun foo() = 1"
+    val input = KotlinInput(code, Parser.parse(code))
+    val tokenRanges = input.characterRangesToTokenRanges(emptyList())
+    assertTrue(tokenRanges.isEmpty)
+  }
+
+  @Test
+  fun `characterRangesToTokenRanges handles multiple disjoint ranges`() {
+    val code = "fun foo() = 1\nfun bar() = 2"
+    val input = KotlinInput(code, Parser.parse(code))
+    val fooOffset = code.indexOf("foo")
+    val barOffset = code.indexOf("bar")
+    val tokenRanges =
+        input.characterRangesToTokenRanges(
+            listOf(
+                Range.closedOpen(fooOffset, fooOffset + 3),
+                Range.closedOpen(barOffset, barOffset + 3),
+            ),
+        )
+    val ranges = tokenRanges.asRanges()
+    assertEquals(2, ranges.size)
+  }
+
+  @Test
+  fun `characterRangesToTokenRanges merges overlapping character ranges`() {
+    val code = "fun testFunction() = 42"
+    val input = KotlinInput(code, Parser.parse(code))
+    val tokenRanges =
+        input.characterRangesToTokenRanges(
+            listOf(
+                Range.closedOpen(0, 10),
+                Range.closedOpen(5, 18),
+            ),
+        )
+    assertEquals(1, tokenRanges.asRanges().size)
+  }
+
+  @Test
+  fun `characterRangesToTokenRanges canonicalizes closed, open, and openClosed ranges`() {
+    val code = "class FooBarBaz {}"
+    val input = KotlinInput(code, Parser.parse(code))
+
+    val fromClosedOpen = input.characterRangesToTokenRanges(listOf(Range.closedOpen(0, 5)))
+    val fromClosed = input.characterRangesToTokenRanges(listOf(Range.closed(0, 4)))
+    val fromOpenClosed = input.characterRangesToTokenRanges(listOf(Range.openClosed(0, 5)))
+
+    assertEquals(fromClosedOpen, fromClosed)
+    assertEquals(
+        TreeRangeSet.create<Int>().apply {
+          add(Range.closedOpen(0, 1))
+        },
+        fromClosedOpen,
+    )
+    assertEquals(
+        TreeRangeSet.create<Int>().apply {
+          add(Range.closedOpen(0, 1))
+        },
+        fromOpenClosed,
+    )
+  }
+
+  @Test
+  fun `characterRangesToTokenRanges clamps range that extends past EOF`() {
+    val code = "class F {}"
+    val input = KotlinInput(code, Parser.parse(code))
+    val tokenRanges =
+        input.characterRangesToTokenRanges(
+            listOf(Range.closedOpen(0, 99999)),
+        )
+    assertFalse(tokenRanges.isEmpty)
+  }
+
+  @Test
+  fun `characterRangesToTokenRanges ignores range starting at or after text length`() {
+    val code = "val x = 1"
+    val input = KotlinInput(code, Parser.parse(code))
+    val tokenRanges =
+        input.characterRangesToTokenRanges(
+            listOf(
+                Range.closedOpen(code.length, code.length + 5),
+                Range.closedOpen(code.length + 10, code.length + 20),
+            ),
+        )
+    assertTrue(tokenRanges.isEmpty)
+  }
+
+  @Test
+  fun `characterRangeToTokenRange with length 0 expands to format line under cursor`() {
+    val code = "val x = 1"
+    val input = KotlinInput(code, Parser.parse(code))
+    val tokenRange = input.characterRangeToTokenRange(0, 0)
+    assertEquals(Range.closedOpen(0, 1), tokenRange)
+  }
+
+  @Test
+  fun `characterRangeToTokenRange with negative length returns empty range`() {
+    val code = "val x = 1"
+    val input = KotlinInput(code, Parser.parse(code))
+    val tokenRange = input.characterRangeToTokenRange(0, -1)
+    assertTrue(tokenRange.isEmpty)
+  }
+
+  @Test
+  fun `characterRangeToTokenRange throws FormatterException when range exceeds text length`() {
+    val code = "val x = 1"
+    val input = KotlinInput(code, Parser.parse(code))
+    val e =
+        assertThrows<FormatterException> {
+          input.characterRangeToTokenRange(5, 100)
+        }
+    assertContains(e.message, "is outside the file")
+  }
+
+  @Test
+  fun `characterRangeToTokenRange returns empty range when range falls entirely in whitespace without tokens`() {
+    val code = "val   x = 1"
+    val input = KotlinInput(code, Parser.parse(code))
+    // Offset 4 is whitespace between 'val' and 'x'
+    val tokenRange = input.characterRangeToTokenRange(4, 1)
+    assertTrue(tokenRange.isEmpty)
+  }
+
+  @Test
+  fun `KotlinInput inspection methods return correct metadata`() {
+    val code = "package test\n\nval x = 1\n"
+    val input = KotlinInput(code, Parser.parse(code))
+
+    assertEquals(code, input.getText())
+    assertTrue(input.getkN() > 0)
+    assertNotNull(input.getToken(0))
+    assertTrue(input.getTokens().isNotEmpty())
+    assertNotNull(input.getPositionTokenMap())
+
+    assertEquals(1, input.getLineNumber(0))
+    assertEquals(0, input.getColumnNumber(0))
+    val line2Pos = code.indexOf("val")
+    assertEquals(3, input.getLineNumber(line2Pos))
+    assertEquals(0, input.getColumnNumber(line2Pos))
+  }
+
+  @Test
+  fun `KotlinInput handles parameter comments and inline comments`() {
+    val code = "fun test(/*flag=*/ enabled: Boolean) {}"
+    val input = KotlinInput(code, Parser.parse(code))
+    val tokens = input.getTokens()
+    assertTrue(tokens.any { it.tok.text == "enabled" })
   }
 }


### PR DESCRIPTION
Implement character offset-based range formatting inspired by Prettier's range options (--range-start and --range-end).

Features:
- `--range-start <int>`: start offset (inclusive, defaults to 0)
- `--range-end <int>`: end offset (exclusive, defaults to EOF)
- Support independent or paired usage with robust bounds validation
- Safe range clamping in Formatter and KotlinInput to prevent out-of-bounds errors
- Shebang offset adjustment and line-ending preservation
- Expanded unit and integration test coverage across CLI, Tokenizer, and Formatter

Fixes: #573, #388