### PR TITLE
Extend the `ExpressionFormatter` to handle all basic expression types

### DIFF
--- a/core/api/ktfmt.api
+++ b/core/api/ktfmt.api
@@ -470,7 +470,7 @@ public abstract interface class org/jetbrains/ktfmt/format/visitor/ExpressionFor
 	public fun formatClassLiteralExpression (Lorg/jetbrains/kotlin/psi/KtClassLiteralExpression;)V
 	public fun formatCollectionLiteralExpression (Lorg/jetbrains/kotlin/psi/KtCollectionLiteralExpression;)V
 	public fun formatConstantExpression (Lorg/jetbrains/kotlin/psi/KtConstantExpression;)V
-	public fun formatInitializerExpression (Lorg/jetbrains/kotlin/psi/KtExpression;)V
+	public fun formatInitializerExpression (Lorg/jetbrains/kotlin/psi/KtExpression;Ljava/lang/String;)V
 	public fun formatIsExpression (Lorg/jetbrains/kotlin/psi/KtIsExpression;)V
 	public fun formatLabeledExpression (Lorg/jetbrains/kotlin/psi/KtLabeledExpression;)V
 	public fun formatParenthesizedExpression (Lorg/jetbrains/kotlin/psi/KtParenthesizedExpression;)V
@@ -569,7 +569,8 @@ public abstract interface class org/jetbrains/ktfmt/format/visitor/KotlinAstForm
 	public fun formatIfExpression (Lorg/jetbrains/kotlin/psi/KtIfExpression;)V
 	public abstract fun formatImportDirective (Lorg/jetbrains/kotlin/psi/KtImportDirective;)V
 	public abstract fun formatImportList (Lorg/jetbrains/kotlin/psi/KtImportList;)V
-	public abstract fun formatInitializerExpression (Lorg/jetbrains/kotlin/psi/KtExpression;)V
+	public abstract fun formatInitializerExpression (Lorg/jetbrains/kotlin/psi/KtExpression;Ljava/lang/String;)V
+	public static synthetic fun formatInitializerExpression$default (Lorg/jetbrains/ktfmt/format/visitor/KotlinAstFormatter;Lorg/jetbrains/kotlin/psi/KtExpression;Ljava/lang/String;ILjava/lang/Object;)V
 	public abstract fun formatIntersectionType (Lorg/jetbrains/kotlin/psi/KtIntersectionType;)V
 	public abstract fun formatIsExpression (Lorg/jetbrains/kotlin/psi/KtIsExpression;)V
 	public abstract fun formatKtFile (Lorg/jetbrains/kotlin/psi/KtFile;)V

--- a/core/api/ktfmt.api
+++ b/core/api/ktfmt.api
@@ -222,19 +222,13 @@ public class org/jetbrains/ktfmt/format/KotlinInputAstVisitor : org/jetbrains/kt
 	public fun getInImport ()Z
 	public fun getOptions ()Lorg/jetbrains/ktfmt/format/FormattingOptions;
 	public fun setInImport (Z)V
-	public fun visitBinaryExpression (Lorg/jetbrains/kotlin/psi/KtBinaryExpression;)V
-	public fun visitBinaryWithTypeRHSExpression (Lorg/jetbrains/kotlin/psi/KtBinaryExpressionWithTypeRHS;)V
 	public fun visitBlockExpression (Lorg/jetbrains/kotlin/psi/KtBlockExpression;)V
 	public fun visitBreakExpression (Lorg/jetbrains/kotlin/psi/KtBreakExpression;)V
 	public fun visitCallExpression (Lorg/jetbrains/kotlin/psi/KtCallExpression;)V
-	public fun visitCallableReferenceExpression (Lorg/jetbrains/kotlin/psi/KtCallableReferenceExpression;)V
 	public fun visitCatchSection (Lorg/jetbrains/kotlin/psi/KtCatchClause;)V
 	public fun visitClassBody (Lorg/jetbrains/kotlin/psi/KtClassBody;)V
 	public fun visitClassInitializer (Lorg/jetbrains/kotlin/psi/KtClassInitializer;)V
-	public fun visitClassLiteralExpression (Lorg/jetbrains/kotlin/psi/KtClassLiteralExpression;)V
 	public fun visitClassOrObject (Lorg/jetbrains/kotlin/psi/KtClassOrObject;)V
-	public fun visitCollectionLiteralExpression (Lorg/jetbrains/kotlin/psi/KtCollectionLiteralExpression;)V
-	public fun visitConstantExpression (Lorg/jetbrains/kotlin/psi/KtConstantExpression;)V
 	public fun visitConstructorDelegationCall (Lorg/jetbrains/kotlin/psi/KtConstructorDelegationCall;)V
 	public fun visitContinueExpression (Lorg/jetbrains/kotlin/psi/KtContinueExpression;)V
 	public fun visitDelegatedSuperTypeEntry (Lorg/jetbrains/kotlin/psi/KtDelegatedSuperTypeEntry;)V
@@ -246,25 +240,13 @@ public class org/jetbrains/ktfmt/format/KotlinInputAstVisitor : org/jetbrains/kt
 	public fun visitFinallySection (Lorg/jetbrains/kotlin/psi/KtFinallySection;)V
 	public fun visitForExpression (Lorg/jetbrains/kotlin/psi/KtForExpression;)V
 	public fun visitIfExpression (Lorg/jetbrains/kotlin/psi/KtIfExpression;)V
-	public fun visitImportDirective (Lorg/jetbrains/kotlin/psi/KtImportDirective;)V
-	public fun visitIsExpression (Lorg/jetbrains/kotlin/psi/KtIsExpression;)V
-	public fun visitLabeledExpression (Lorg/jetbrains/kotlin/psi/KtLabeledExpression;)V
 	public fun visitNamedFunction (Lorg/jetbrains/kotlin/psi/KtNamedFunction;)V
-	public fun visitPackageDirective (Lorg/jetbrains/kotlin/psi/KtPackageDirective;)V
 	public fun visitParameter (Lorg/jetbrains/kotlin/psi/KtParameter;)V
-	public fun visitParenthesizedExpression (Lorg/jetbrains/kotlin/psi/KtParenthesizedExpression;)V
-	public fun visitPostfixExpression (Lorg/jetbrains/kotlin/psi/KtPostfixExpression;)V
-	public fun visitPrefixExpression (Lorg/jetbrains/kotlin/psi/KtPrefixExpression;)V
 	public fun visitPrimaryConstructor (Lorg/jetbrains/kotlin/psi/KtPrimaryConstructor;)V
 	public fun visitProperty (Lorg/jetbrains/kotlin/psi/KtProperty;)V
-	public fun visitReferenceExpression (Lorg/jetbrains/kotlin/psi/KtReferenceExpression;)V
 	public fun visitReturnExpression (Lorg/jetbrains/kotlin/psi/KtReturnExpression;)V
 	public fun visitSecondaryConstructor (Lorg/jetbrains/kotlin/psi/KtSecondaryConstructor;)V
-	public fun visitSimpleNameExpression (Lorg/jetbrains/kotlin/psi/KtSimpleNameExpression;)V
-	public fun visitStringTemplateExpression (Lorg/jetbrains/kotlin/psi/KtStringTemplateExpression;)V
-	public fun visitSuperExpression (Lorg/jetbrains/kotlin/psi/KtSuperExpression;)V
 	public fun visitSuperTypeCallEntry (Lorg/jetbrains/kotlin/psi/KtSuperTypeCallEntry;)V
-	public fun visitThisExpression (Lorg/jetbrains/kotlin/psi/KtThisExpression;)V
 	public fun visitThrowExpression (Lorg/jetbrains/kotlin/psi/KtThrowExpression;)V
 	public fun visitTryExpression (Lorg/jetbrains/kotlin/psi/KtTryExpression;)V
 	public fun visitTypeAlias (Lorg/jetbrains/kotlin/psi/KtTypeAlias;)V
@@ -482,12 +464,30 @@ public abstract interface class org/jetbrains/ktfmt/format/visitor/CallFormatter
 }
 
 public abstract interface class org/jetbrains/ktfmt/format/visitor/ExpressionFormatter : org/jetbrains/ktfmt/format/visitor/KotlinAstFormatter {
+	public fun formatBinaryExpression (Lorg/jetbrains/kotlin/psi/KtBinaryExpression;)V
+	public fun formatBinaryWithTypeRHSExpression (Lorg/jetbrains/kotlin/psi/KtBinaryExpressionWithTypeRHS;)V
+	public fun formatCallableReferenceExpression (Lorg/jetbrains/kotlin/psi/KtCallableReferenceExpression;)V
+	public fun formatClassLiteralExpression (Lorg/jetbrains/kotlin/psi/KtClassLiteralExpression;)V
+	public fun formatCollectionLiteralExpression (Lorg/jetbrains/kotlin/psi/KtCollectionLiteralExpression;)V
+	public fun formatConstantExpression (Lorg/jetbrains/kotlin/psi/KtConstantExpression;)V
 	public fun formatInitializerExpression (Lorg/jetbrains/kotlin/psi/KtExpression;)V
+	public fun formatIsExpression (Lorg/jetbrains/kotlin/psi/KtIsExpression;)V
+	public fun formatLabeledExpression (Lorg/jetbrains/kotlin/psi/KtLabeledExpression;)V
+	public fun formatParenthesizedExpression (Lorg/jetbrains/kotlin/psi/KtParenthesizedExpression;)V
+	public fun formatPostfixExpression (Lorg/jetbrains/kotlin/psi/KtPostfixExpression;)V
+	public fun formatPrefixExpression (Lorg/jetbrains/kotlin/psi/KtPrefixExpression;)V
+	public fun formatReferenceExpression (Lorg/jetbrains/kotlin/psi/KtReferenceExpression;)V
+	public fun formatSimpleNameExpression (Lorg/jetbrains/kotlin/psi/KtSimpleNameExpression;)V
+	public fun formatStringTemplateExpression (Lorg/jetbrains/kotlin/psi/KtStringTemplateExpression;)V
+	public fun formatSuperExpression (Lorg/jetbrains/kotlin/psi/KtSuperExpression;)V
+	public fun formatThisExpression (Lorg/jetbrains/kotlin/psi/KtThisExpression;)V
 }
 
 public abstract interface class org/jetbrains/ktfmt/format/visitor/FileFormatter : org/jetbrains/ktfmt/format/visitor/KotlinAstFormatter {
+	public fun formatImportDirective (Lorg/jetbrains/kotlin/psi/KtImportDirective;)V
 	public fun formatKtFile (Lorg/jetbrains/kotlin/psi/KtFile;)V
 	public fun formatKtScript (Lorg/jetbrains/kotlin/psi/KtScript;)V
+	public fun formatPackageDirective (Lorg/jetbrains/kotlin/psi/KtPackageDirective;)V
 	public fun formatStatement (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;)V
 	public fun formatStatements ([Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;)V
 }
@@ -533,24 +533,24 @@ public abstract interface class org/jetbrains/ktfmt/format/visitor/KotlinAstForm
 	public abstract fun formatAnnotationEntry (Lorg/jetbrains/kotlin/psi/KtAnnotationEntry;)V
 	public abstract fun formatAnnotationUseSiteTarget (Lorg/jetbrains/kotlin/psi/KtAnnotationUseSiteTarget;)V
 	public abstract fun formatArgument (Lorg/jetbrains/kotlin/psi/KtValueArgument;ZLcom/google/googlejavaformat/Output$BreakTag;)V
-	public fun formatArrayAccessExpression (Lorg/jetbrains/kotlin/psi/KtArrayAccessExpression;)V
-	public fun formatBinaryExpression (Lorg/jetbrains/kotlin/psi/KtBinaryExpression;)V
-	public fun formatBinaryWithTypeRHSExpression (Lorg/jetbrains/kotlin/psi/KtBinaryExpressionWithTypeRHS;)V
+	public abstract fun formatArrayAccessExpression (Lorg/jetbrains/kotlin/psi/KtArrayAccessExpression;)V
+	public abstract fun formatBinaryExpression (Lorg/jetbrains/kotlin/psi/KtBinaryExpression;)V
+	public abstract fun formatBinaryWithTypeRHSExpression (Lorg/jetbrains/kotlin/psi/KtBinaryExpressionWithTypeRHS;)V
 	public fun formatBlockExpression (Lorg/jetbrains/kotlin/psi/KtBlockExpression;)V
 	public fun formatBreakExpression (Lorg/jetbrains/kotlin/psi/KtBreakExpression;)V
 	public fun formatCallExpression (Lorg/jetbrains/kotlin/psi/KtCallExpression;)V
-	public fun formatCallableReferenceExpression (Lorg/jetbrains/kotlin/psi/KtCallableReferenceExpression;)V
+	public abstract fun formatCallableReferenceExpression (Lorg/jetbrains/kotlin/psi/KtCallableReferenceExpression;)V
 	public fun formatCatchSection (Lorg/jetbrains/kotlin/psi/KtCatchClause;)V
 	public abstract fun formatChainedBlockLikeCall (Lorg/jetbrains/kotlin/psi/KtQualifiedExpression;Z)V
 	public abstract fun formatChainedScopingFunction (Lorg/jetbrains/kotlin/psi/KtQualifiedExpression;Z)V
 	public fun formatClassBody (Lorg/jetbrains/kotlin/psi/KtClassBody;)V
 	public fun formatClassInitializer (Lorg/jetbrains/kotlin/psi/KtClassInitializer;)V
-	public fun formatClassLiteralExpression (Lorg/jetbrains/kotlin/psi/KtClassLiteralExpression;)V
+	public abstract fun formatClassLiteralExpression (Lorg/jetbrains/kotlin/psi/KtClassLiteralExpression;)V
 	public fun formatClassOrObject (Lorg/jetbrains/kotlin/psi/KtClassOrObject;)V
-	public fun formatCollectionLiteralExpression (Lorg/jetbrains/kotlin/psi/KtCollectionLiteralExpression;)V
+	public abstract fun formatCollectionLiteralExpression (Lorg/jetbrains/kotlin/psi/KtCollectionLiteralExpression;)V
 	public abstract fun formatCommaSeparatedList (Ljava/lang/Iterable;ZZZLjava/lang/String;Ljava/lang/String;ZZ)Lcom/google/googlejavaformat/Output$BreakTag;
 	public static synthetic fun formatCommaSeparatedList$default (Lorg/jetbrains/ktfmt/format/visitor/KotlinAstFormatter;Ljava/lang/Iterable;ZZZLjava/lang/String;Ljava/lang/String;ZZILjava/lang/Object;)Lcom/google/googlejavaformat/Output$BreakTag;
-	public fun formatConstantExpression (Lorg/jetbrains/kotlin/psi/KtConstantExpression;)V
+	public abstract fun formatConstantExpression (Lorg/jetbrains/kotlin/psi/KtConstantExpression;)V
 	public fun formatConstructorDelegationCall (Lorg/jetbrains/kotlin/psi/KtConstructorDelegationCall;)V
 	public abstract fun formatContextReceiverList (Lorg/jetbrains/kotlin/psi/KtContextReceiverList;)V
 	public fun formatContinueExpression (Lorg/jetbrains/kotlin/psi/KtContinueExpression;)V
@@ -567,40 +567,40 @@ public abstract interface class org/jetbrains/ktfmt/format/visitor/KotlinAstForm
 	public static synthetic fun formatFunctionCall$default (Lorg/jetbrains/ktfmt/format/visitor/KotlinAstFormatter;Lorg/jetbrains/kotlin/psi/KtExpression;Lorg/jetbrains/kotlin/psi/KtTypeArgumentList;Lorg/jetbrains/kotlin/psi/KtValueArgumentList;Lorg/jetbrains/kotlin/psi/KtLambdaArgument;Lorg/jetbrains/ktfmt/format/visitor/Indentation;Lorg/jetbrains/ktfmt/format/visitor/Indentation;ILjava/lang/Object;)V
 	public abstract fun formatFunctionType (Lorg/jetbrains/kotlin/psi/KtFunctionType;)V
 	public fun formatIfExpression (Lorg/jetbrains/kotlin/psi/KtIfExpression;)V
-	public fun formatImportDirective (Lorg/jetbrains/kotlin/psi/KtImportDirective;)V
+	public abstract fun formatImportDirective (Lorg/jetbrains/kotlin/psi/KtImportDirective;)V
 	public abstract fun formatImportList (Lorg/jetbrains/kotlin/psi/KtImportList;)V
 	public abstract fun formatInitializerExpression (Lorg/jetbrains/kotlin/psi/KtExpression;)V
 	public abstract fun formatIntersectionType (Lorg/jetbrains/kotlin/psi/KtIntersectionType;)V
-	public fun formatIsExpression (Lorg/jetbrains/kotlin/psi/KtIsExpression;)V
+	public abstract fun formatIsExpression (Lorg/jetbrains/kotlin/psi/KtIsExpression;)V
 	public abstract fun formatKtFile (Lorg/jetbrains/kotlin/psi/KtFile;)V
 	public abstract fun formatKtScript (Lorg/jetbrains/kotlin/psi/KtScript;)V
-	public fun formatLabeledExpression (Lorg/jetbrains/kotlin/psi/KtLabeledExpression;)V
+	public abstract fun formatLabeledExpression (Lorg/jetbrains/kotlin/psi/KtLabeledExpression;)V
 	public abstract fun formatLambdaExpression (Lorg/jetbrains/kotlin/psi/KtLambdaExpression;Lcom/google/googlejavaformat/Output$BreakTag;)V
 	public abstract fun formatLambdaOrScopingFunction (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;Z)V
 	public static synthetic fun formatLambdaOrScopingFunction$default (Lorg/jetbrains/ktfmt/format/visitor/KotlinAstFormatter;Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;ZILjava/lang/Object;)V
 	public abstract fun formatModifierList (Lorg/jetbrains/kotlin/psi/KtModifierList;)V
 	public fun formatNamedFunction (Lorg/jetbrains/kotlin/psi/KtNamedFunction;)V
 	public abstract fun formatNullableType (Lorg/jetbrains/kotlin/psi/KtNullableType;)V
-	public fun formatPackageDirective (Lorg/jetbrains/kotlin/psi/KtPackageDirective;)V
+	public abstract fun formatPackageDirective (Lorg/jetbrains/kotlin/psi/KtPackageDirective;)V
 	public fun formatParameter (Lorg/jetbrains/kotlin/psi/KtParameter;)V
 	public abstract fun formatParameterList (Lorg/jetbrains/kotlin/psi/KtParameterList;)V
-	public fun formatParenthesizedExpression (Lorg/jetbrains/kotlin/psi/KtParenthesizedExpression;)V
-	public fun formatPostfixExpression (Lorg/jetbrains/kotlin/psi/KtPostfixExpression;)V
-	public fun formatPrefixExpression (Lorg/jetbrains/kotlin/psi/KtPrefixExpression;)V
+	public abstract fun formatParenthesizedExpression (Lorg/jetbrains/kotlin/psi/KtParenthesizedExpression;)V
+	public abstract fun formatPostfixExpression (Lorg/jetbrains/kotlin/psi/KtPostfixExpression;)V
+	public abstract fun formatPrefixExpression (Lorg/jetbrains/kotlin/psi/KtPrefixExpression;)V
 	public fun formatPrimaryConstructor (Lorg/jetbrains/kotlin/psi/KtPrimaryConstructor;)V
 	public fun formatProperty (Lorg/jetbrains/kotlin/psi/KtProperty;)V
 	public abstract fun formatQualifiedExpression (Lorg/jetbrains/kotlin/psi/KtQualifiedExpression;)V
-	public fun formatReferenceExpression (Lorg/jetbrains/kotlin/psi/KtReferenceExpression;)V
+	public abstract fun formatReferenceExpression (Lorg/jetbrains/kotlin/psi/KtReferenceExpression;)V
 	public fun formatReturnExpression (Lorg/jetbrains/kotlin/psi/KtReturnExpression;)V
 	public fun formatSecondaryConstructor (Lorg/jetbrains/kotlin/psi/KtSecondaryConstructor;)V
-	public fun formatSimpleNameExpression (Lorg/jetbrains/kotlin/psi/KtSimpleNameExpression;)V
+	public abstract fun formatSimpleNameExpression (Lorg/jetbrains/kotlin/psi/KtSimpleNameExpression;)V
 	public abstract fun formatStatement (Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;)V
 	public abstract fun formatStatements ([Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;)V
-	public fun formatStringTemplateExpression (Lorg/jetbrains/kotlin/psi/KtStringTemplateExpression;)V
-	public fun formatSuperExpression (Lorg/jetbrains/kotlin/psi/KtSuperExpression;)V
+	public abstract fun formatStringTemplateExpression (Lorg/jetbrains/kotlin/psi/KtStringTemplateExpression;)V
+	public abstract fun formatSuperExpression (Lorg/jetbrains/kotlin/psi/KtSuperExpression;)V
 	public fun formatSuperTypeCallEntry (Lorg/jetbrains/kotlin/psi/KtSuperTypeCallEntry;)V
 	public abstract fun formatSuperTypeList (Lorg/jetbrains/kotlin/psi/KtSuperTypeList;)V
-	public fun formatThisExpression (Lorg/jetbrains/kotlin/psi/KtThisExpression;)V
+	public abstract fun formatThisExpression (Lorg/jetbrains/kotlin/psi/KtThisExpression;)V
 	public fun formatThrowExpression (Lorg/jetbrains/kotlin/psi/KtThrowExpression;)V
 	public fun formatTryExpression (Lorg/jetbrains/kotlin/psi/KtTryExpression;)V
 	public fun formatTypeAlias (Lorg/jetbrains/kotlin/psi/KtTypeAlias;)V

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/KotlinInputAstVisitor.kt
@@ -28,7 +28,6 @@ import java.util.ArrayDeque
 import java.util.Optional
 import kotlin.jvm.optionals.getOrNull
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.com.intellij.psi.stubs.PsiFileStubImpl
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtBackingField
 import org.jetbrains.kotlin.psi.KtBlockExpression
@@ -76,8 +75,6 @@ import org.jetbrains.kotlin.psi.KtWhenConditionWithExpression
 import org.jetbrains.kotlin.psi.KtWhenExpression
 import org.jetbrains.kotlin.psi.KtWhileExpression
 import org.jetbrains.kotlin.psi.psiUtil.startOffset
-import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
-import org.jetbrains.kotlin.psi.stubs.impl.KotlinPlaceHolderStubImpl
 import org.jetbrains.ktfmt.format.visitor.AbstractFormatterVisitor
 import org.jetbrains.ktfmt.format.visitor.AnnotationFormatter
 import org.jetbrains.ktfmt.format.visitor.CallFormatter
@@ -463,7 +460,7 @@ open class KotlinInputAstVisitor(
                     typeParameters = null,
                     receiverTypeReference = null,
                     name = null,
-                    parameterList = getParameterListWithBugFixes(component),
+                    parameterList = component.parameterList,
                     typeConstraintList = null,
                     bodyExpression = component.bodyBlockExpression ?: component.bodyExpression,
                     typeOrDelegationCall = component.returnTypeReference,
@@ -504,35 +501,6 @@ open class KotlinInputAstVisitor(
       if (initializer != null) {
         builder.space()
         formatInitializerExpression(initializer)
-      }
-    }
-  }
-
-  // Bug in Kotlin 1.9.10: KtPropertyAccessor is the direct parent of the left and right paren
-  // elements. Also parameterList is always null for getters. As a workaround, we create our own
-  // fake KtParameterList.
-  // TODO: won't need this after https://youtrack.jetbrains.com/issue/KT-70922
-  private fun getParameterListWithBugFixes(accessor: KtPropertyAccessor): KtParameterList? {
-    if (accessor.bodyExpression == null && accessor.bodyBlockExpression == null) return null
-
-    val stub = accessor.stub ?: PsiFileStubImpl(accessor.containingFile)
-
-    return object :
-        KtParameterList(KotlinPlaceHolderStubImpl(stub, KtStubElementTypes.VALUE_PARAMETER_LIST)) {
-      override fun getParameters(): List<KtParameter> {
-        return accessor.valueParameters
-      }
-
-      override fun getTrailingComma(): PsiElement? {
-        return accessor.parameterList?.trailingComma
-      }
-
-      override fun getLeftParenthesis(): PsiElement? {
-        return accessor.parameterList?.leftParenthesis
-      }
-
-      override fun getRightParenthesis(): PsiElement? {
-        return accessor.parameterList?.rightParenthesis
       }
     }
   }

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/KotlinInputAstVisitor.kt
@@ -31,22 +31,15 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.stubs.PsiFileStubImpl
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtBackingField
-import org.jetbrains.kotlin.psi.KtBinaryExpression
-import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtBreakExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
 import org.jetbrains.kotlin.psi.KtCatchClause
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassBody
 import org.jetbrains.kotlin.psi.KtClassInitializer
-import org.jetbrains.kotlin.psi.KtClassLiteralExpression
 import org.jetbrains.kotlin.psi.KtClassOrObject
-import org.jetbrains.kotlin.psi.KtCollectionLiteralExpression
-import org.jetbrains.kotlin.psi.KtConstantExpression
 import org.jetbrains.kotlin.psi.KtConstructorDelegationCall
-import org.jetbrains.kotlin.psi.KtContainerNode
 import org.jetbrains.kotlin.psi.KtContextReceiverList
 import org.jetbrains.kotlin.psi.KtContinueExpression
 import org.jetbrains.kotlin.psi.KtDelegatedSuperTypeEntry
@@ -59,39 +52,24 @@ import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFinallySection
 import org.jetbrains.kotlin.psi.KtForExpression
 import org.jetbrains.kotlin.psi.KtIfExpression
-import org.jetbrains.kotlin.psi.KtImportDirective
-import org.jetbrains.kotlin.psi.KtIsExpression
-import org.jetbrains.kotlin.psi.KtLabelReferenceExpression
-import org.jetbrains.kotlin.psi.KtLabeledExpression
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtModifierList
 import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtParameterList
-import org.jetbrains.kotlin.psi.KtParenthesizedExpression
-import org.jetbrains.kotlin.psi.KtPostfixExpression
-import org.jetbrains.kotlin.psi.KtPrefixExpression
 import org.jetbrains.kotlin.psi.KtPrimaryConstructor
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
 import org.jetbrains.kotlin.psi.KtPropertyDelegate
-import org.jetbrains.kotlin.psi.KtQualifiedExpression
-import org.jetbrains.kotlin.psi.KtReferenceExpression
 import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.KtSecondaryConstructor
-import org.jetbrains.kotlin.psi.KtSimpleNameExpression
-import org.jetbrains.kotlin.psi.KtStringTemplateExpression
-import org.jetbrains.kotlin.psi.KtSuperExpression
 import org.jetbrains.kotlin.psi.KtSuperTypeCallEntry
-import org.jetbrains.kotlin.psi.KtThisExpression
 import org.jetbrains.kotlin.psi.KtThrowExpression
 import org.jetbrains.kotlin.psi.KtTryExpression
 import org.jetbrains.kotlin.psi.KtTypeAlias
 import org.jetbrains.kotlin.psi.KtTypeConstraintList
 import org.jetbrains.kotlin.psi.KtTypeParameterList
 import org.jetbrains.kotlin.psi.KtTypeReference
-import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.KtWhenConditionInRange
 import org.jetbrains.kotlin.psi.KtWhenConditionIsPattern
 import org.jetbrains.kotlin.psi.KtWhenConditionWithExpression
@@ -114,12 +92,10 @@ import org.jetbrains.ktfmt.format.visitor.breakOp
 import org.jetbrains.ktfmt.format.visitor.fenceComments
 import org.jetbrains.ktfmt.format.visitor.forcedBreak
 import org.jetbrains.ktfmt.format.visitor.hasEmptyParenthesis
-import org.jetbrains.ktfmt.format.visitor.hasLineBreakingCommentBefore
 import org.jetbrains.ktfmt.format.visitor.isBlockLikeCall
 import org.jetbrains.ktfmt.format.visitor.isChainedBlockLikeCall
 import org.jetbrains.ktfmt.format.visitor.isChainedScopingFunction
 import org.jetbrains.ktfmt.format.visitor.isLambdaOrScopingFunction
-import org.jetbrains.ktfmt.format.visitor.open
 import org.jetbrains.ktfmt.format.visitor.sync
 import org.jetbrains.ktfmt.format.visitor.token
 import org.jetbrains.ktfmt.format.visitor.trailingLambda
@@ -345,39 +321,6 @@ open class KotlinInputAstVisitor(
     }
   }
 
-  /** Example `this` or `this@Foo` */
-  override fun visitThisExpression(expression: KtThisExpression) {
-    builder.sync(expression)
-    builder.token("this")
-    visit(expression.getTargetLabel())
-  }
-
-  /** Example `Foo` or `@Foo` */
-  override fun visitSimpleNameExpression(expression: KtSimpleNameExpression) {
-    builder.sync(expression)
-    when (expression) {
-      is KtLabelReferenceExpression -> {
-        if (expression.text[0] == '@') {
-          builder.token("@")
-          builder.token(expression.getIdentifier()?.text ?: fail())
-        } else {
-          builder.token(expression.getIdentifier()?.text ?: fail())
-          builder.token("@")
-        }
-      }
-      else -> {
-        if (expression.text.isNotEmpty()) {
-          builder.token(expression.text)
-        }
-      }
-    }
-  }
-
-  override fun visitReferenceExpression(expression: KtReferenceExpression) {
-    builder.sync(expression)
-    builder.token(expression.text)
-  }
-
   override fun visitReturnExpression(expression: KtReturnExpression) {
     builder.sync(expression)
     builder.token("return")
@@ -388,117 +331,6 @@ open class KotlinInputAstVisitor(
       visit(returnedExpression)
     }
     builder.guessToken(";")
-  }
-
-  /**
-   * For example `a + b`, `a + b + c` or `a..b`
-   *
-   * The extra handling here drills to the left most expression and handles it for long chains of
-   * binary expressions that are formatted not accordingly to the associative values That is, we
-   * want to think of `a + b + c` as `(a + b) + c`, whereas the AST parses it as `a + (b + c)`
-   */
-  override fun visitBinaryExpression(expression: KtBinaryExpression) {
-    builder.sync(expression)
-    val op = expression.operationToken
-
-    if (KtTokens.ALL_ASSIGNMENTS.contains(op) && expression.right.isLambdaOrScopingFunction) {
-      // Assignments are statements in Kotlin; we don't have to worry about compound assignment.
-      visit(expression.left)
-      builder.space()
-      builder.token(expression.operationReference.text)
-      formatLambdaOrScopingFunction(expression.right)
-      return
-    }
-
-    val parts =
-        ArrayDeque<KtBinaryExpression>().apply {
-          var current: KtExpression? = expression
-          while (current is KtBinaryExpression && current.operationToken == op) {
-            addFirst(current)
-            current = current.left
-          }
-        }
-
-    val leftMostExpression = parts.first()
-    visit(leftMostExpression.left)
-    for (leftExpression in parts) {
-      val isFirst = leftExpression === leftMostExpression
-
-      when (leftExpression.operationToken) {
-        KtTokens.RANGE,
-        KtTokens.RANGE_UNTIL -> {
-          if (isFirst) {
-            builder.open(expressionBreakIndent)
-          }
-          builder.token(leftExpression.operationReference.text)
-        }
-        KtTokens.ELVIS -> {
-          if (isFirst) {
-            builder.open(expressionBreakIndent)
-          }
-          builder.breakOp(Doc.FillMode.UNIFIED, " ", ZERO)
-          builder.token(leftExpression.operationReference.text)
-          builder.space()
-        }
-        else -> {
-          builder.space()
-          if (isFirst) {
-            builder.open(expressionBreakIndent)
-          }
-          builder.token(leftExpression.operationReference.text)
-          val fillMode =
-              if (leftExpression.operationReference.hasLineBreakingCommentBefore)
-                  Doc.FillMode.INDEPENDENT
-              else Doc.FillMode.UNIFIED
-          builder.breakOp(fillMode, " ", ZERO)
-        }
-      }
-      visit(leftExpression.right)
-    }
-    builder.close()
-  }
-
-  override fun visitPostfixExpression(expression: KtPostfixExpression) {
-    builder.sync(expression)
-    builder.block(ZERO) {
-      val baseExpression = expression.baseExpression
-      val operator = expression.operationReference.text
-
-      visit(baseExpression)
-      if (
-          baseExpression is KtPostfixExpression &&
-              baseExpression.operationReference.text.last() == operator.first()
-      ) {
-        builder.space()
-      }
-      builder.token(operator)
-    }
-  }
-
-  override fun visitPrefixExpression(expression: KtPrefixExpression) {
-    builder.sync(expression)
-    builder.block(ZERO) {
-      val baseExpression = expression.baseExpression
-      val operator = expression.operationReference.text
-
-      builder.token(operator)
-      if (
-          baseExpression is KtPrefixExpression &&
-              operator.last() == baseExpression.operationReference.text.first()
-      ) {
-        builder.space()
-      }
-      visit(baseExpression)
-    }
-  }
-
-  override fun visitLabeledExpression(expression: KtLabeledExpression) {
-    builder.sync(expression)
-    visit(expression.labelQualifier)
-    if (expression.baseExpression !is KtLambdaExpression) {
-      builder.space()
-    }
-    visit(expression.baseExpression)
   }
 
   internal enum class DeclarationKind {
@@ -818,71 +650,6 @@ open class KotlinInputAstVisitor(
     visit(initializer.body)
   }
 
-  override fun visitConstantExpression(expression: KtConstantExpression) {
-    builder.sync(expression)
-    builder.token(expression.text)
-  }
-
-  /** Example `(1 + 1)` */
-  override fun visitParenthesizedExpression(expression: KtParenthesizedExpression) {
-    builder.sync(expression)
-    builder.token("(")
-    visit(expression.expression)
-    builder.token(")")
-  }
-
-  override fun visitPackageDirective(directive: KtPackageDirective) {
-    builder.sync(directive)
-    if (directive.packageKeyword == null) {
-      return
-    }
-    builder.token("package")
-    builder.space()
-    var first = true
-    for (packageName in directive.packageNames) {
-      if (first) {
-        first = false
-      } else {
-        builder.token(".")
-      }
-      builder.token(packageName.getIdentifier()?.text ?: packageName.getReferencedName())
-    }
-
-    builder.guessToken(";")
-    builder.forcedBreak()
-  }
-
-  /** Example `import com.foo.A` */
-  override fun visitImportDirective(directive: KtImportDirective) {
-    builder.sync(directive)
-    builder.token("import")
-    builder.space()
-
-    val importedReference = directive.importedReference
-    if (importedReference != null) {
-      inImport = true
-      visit(importedReference)
-      inImport = false
-    }
-    if (directive.isAllUnder) {
-      builder.token(".")
-      builder.token("*")
-    }
-
-    // Possible alias.
-    val alias = directive.alias?.nameIdentifier
-    if (alias != null) {
-      builder.space()
-      builder.token("as")
-      builder.space()
-      builder.token(alias.text ?: fail())
-    }
-
-    // Force a newline afterwards.
-    builder.guessToken(";")
-    builder.forcedBreak()
-  }
-
   override fun visitSuperTypeCallEntry(call: KtSuperTypeCallEntry) {
     builder.sync(call)
     formatFunctionCall(call.calleeExpression, null, call.valueArgumentList, call.trailingLambda)
@@ -1133,25 +900,6 @@ open class KotlinInputAstVisitor(
     )
   }
 
-  /** Example `"Hello $world!"` or `"""Hello world!"""` */
-  override fun visitStringTemplateExpression(expression: KtStringTemplateExpression) {
-    builder.sync(expression)
-    builder.token(WhitespaceTombstones.replaceTrailingWhitespaceWithTombstone(expression.text))
-  }
-
-  /** Example `super` in `super.doIt(5)` or `super<Foo>` in `super<Foo>.doIt(5)` */
-  override fun visitSuperExpression(expression: KtSuperExpression) {
-    builder.sync(expression)
-    builder.token("super")
-    val superTypeQualifier = expression.superTypeQualifier
-    if (superTypeQualifier != null) {
-      builder.token("<")
-      visit(superTypeQualifier)
-      builder.token(">")
-    }
-    visit(expression.labelQualifier)
-  }
-
   /** Example `for (i in items) { ... }` */
   override fun visitForExpression(expression: KtForExpression) {
     builder.sync(expression)
@@ -1231,101 +979,6 @@ open class KotlinInputAstVisitor(
             initializer = parameter.defaultValue,
         )
       }
-    }
-  }
-
-  /** Example `String::isNullOrEmpty` */
-  override fun visitCallableReferenceExpression(expression: KtCallableReferenceExpression) {
-    builder.sync(expression)
-    visit(expression.receiverExpression)
-
-    // For some reason, expression.receiverExpression doesn't contain the question-mark token in
-    // case of a nullable type, e.g., in String?::isNullOrEmpty.
-    // Instead, KtCallableReferenceExpression exposes a method that looks for the QUEST token in
-    // its children.
-    if (expression.hasQuestionMarks) {
-      builder.token("?")
-    }
-
-    builder.block(expressionBreakIndent) {
-      builder.token("::")
-      builder.breakOp(Doc.FillMode.INDEPENDENT, "", ZERO)
-      visit(expression.callableReference)
-    }
-  }
-
-  override fun visitClassLiteralExpression(expression: KtClassLiteralExpression) {
-    builder.sync(expression)
-    val receiverExpression = expression.receiverExpression
-    if (receiverExpression is KtCallExpression) {
-      formatFunctionCall(
-          receiverExpression.calleeExpression,
-          receiverExpression.typeArgumentList,
-          receiverExpression.valueArgumentList,
-          receiverExpression.trailingLambda,
-      )
-    } else {
-      visit(receiverExpression)
-    }
-    builder.token("::")
-    builder.token("class")
-  }
-
-  /** Example `a is Int` or `b !is Int` */
-  override fun visitIsExpression(expression: KtIsExpression) {
-    builder.sync(expression)
-    val openGroupBeforeLeft = expression.leftHandSide !is KtQualifiedExpression
-    if (openGroupBeforeLeft) builder.open(ZERO)
-    visit(expression.leftHandSide)
-    if (!openGroupBeforeLeft) builder.open(ZERO)
-    val parent = expression.parent
-    if (
-        parent is KtValueArgument ||
-            parent is KtParenthesizedExpression ||
-            parent is KtContainerNode
-    ) {
-      builder.breakOp(Doc.FillMode.UNIFIED, " ", expressionBreakIndent)
-    } else {
-      builder.space()
-    }
-    visit(expression.operationReference)
-    builder.breakOp(Doc.FillMode.INDEPENDENT, " ", expressionBreakIndent)
-    builder.block(expressionBreakIndent) { visit(expression.typeReference) }
-    builder.close()
-  }
-
-  /** Example `a as Int` or `a as? Int` */
-  override fun visitBinaryWithTypeRHSExpression(expression: KtBinaryExpressionWithTypeRHS) {
-    builder.sync(expression)
-    val openGroupBeforeLeft = expression.left !is KtQualifiedExpression
-    if (openGroupBeforeLeft) builder.open(ZERO)
-    visit(expression.left)
-    if (!openGroupBeforeLeft) builder.open(ZERO)
-    builder.breakOp(Doc.FillMode.UNIFIED, " ", expressionBreakIndent)
-    visit(expression.operationReference)
-    builder.breakOp(Doc.FillMode.INDEPENDENT, " ", expressionBreakIndent)
-    builder.block(expressionBreakIndent) { visit(expression.right) }
-    builder.close()
-  }
-
-  /**
-   * Example:
-   * ```
-   * fun f() {
-   *   val a: Array<Int> = [1, 2, 3]
-   * }
-   * ```
-   */
-  override fun visitCollectionLiteralExpression(expression: KtCollectionLiteralExpression) {
-    builder.sync(expression)
-    builder.block(expressionBreakIndent) {
-      formatCommaSeparatedList(
-          expression.getInnerExpressions(),
-          forceMultiline = expression.trailingComma != null,
-          prefix = "[",
-          postfix = "]",
-          wrapInBlock = !options.manageTrailingCommas,
-      )
     }
   }
 

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/ExpressionFormatter.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/ExpressionFormatter.kt
@@ -33,8 +33,8 @@ import org.jetbrains.ktfmt.format.visitor.Indentation.Companion.ZERO
  * - Any function call-related expressions are handled in [CallFormatter]
  */
 interface ExpressionFormatter : KotlinAstFormatter {
-  override fun formatInitializerExpression(initializer: KtExpression) {
-    builder.token("=")
+  override fun formatInitializerExpression(initializer: KtExpression, assignmentOp: String) {
+    builder.token(assignmentOp)
     if (initializer.isLambdaOrScopingFunction) {
       formatLambdaOrScopingFunction(initializer)
     } else if (initializer.isChainedScopingFunction) {
@@ -53,23 +53,22 @@ interface ExpressionFormatter : KotlinAstFormatter {
     }
   }
 
-  /** Example `this` or `this@Foo` */
   override fun formatThisExpression(expression: KtThisExpression) {
     builder.sync(expression)
     builder.token("this")
     format(expression.getTargetLabel())
   }
 
-  /** Example `Foo` or `@Foo` */
   override fun formatSimpleNameExpression(expression: KtSimpleNameExpression) {
     builder.sync(expression)
     when (expression) {
       is KtLabelReferenceExpression -> {
+        val identifier = expression.getIdentifier()?.text ?: fail()
         if (expression.text[0] == '@') {
           builder.token("@")
-          builder.token(expression.getIdentifier()?.text ?: fail())
+          builder.token(identifier)
         } else {
-          builder.token(expression.getIdentifier()?.text ?: fail())
+          builder.token(identifier)
           builder.token("@")
         }
       }
@@ -87,11 +86,11 @@ interface ExpressionFormatter : KotlinAstFormatter {
   }
 
   /**
-   * For example `a + b`, `a + b + c` or `a..b`
+   * We unwrap the left most expression from a chain of binary expressions and format the
+   * expressions left to right. For example `a + b + c + d` is parsed as `a + (b + (c + d))`, but we
+   * format is as `((a + b) + c) + d`.
    *
-   * The extra handling here drills to the left most expression and handles it for long chains of
-   * binary expressions that are formatted not accordingly to the associative values That is, we
-   * want to think of `a + b + c` as `(a + b) + c`, whereas the AST parses it as `a + (b + c)`
+   * @see [KtBinaryExpression.fullChain].
    */
   override fun formatBinaryExpression(expression: KtBinaryExpression) {
     builder.sync(expression)
@@ -101,57 +100,48 @@ interface ExpressionFormatter : KotlinAstFormatter {
       // Assignments are statements in Kotlin; we don't have to worry about compound assignment.
       format(expression.left)
       builder.space()
-      builder.token(expression.operationReference.text)
-      formatLambdaOrScopingFunction(expression.right)
+      formatInitializerExpression(expression.right!!, expression.operationReference.text)
       return
     }
 
-    val parts =
-        ArrayDeque<KtBinaryExpression>().apply {
-          var current: KtExpression? = expression
-          while (current is KtBinaryExpression && current.operationToken == op) {
-            addFirst(current)
-            current = current.left
-          }
-        }
-
-    val leftMostExpression = parts.first()
-    format(leftMostExpression.left)
-    for (leftExpression in parts) {
-      val isFirst = leftExpression === leftMostExpression
-
-      when (leftExpression.operationToken) {
-        KtTokens.RANGE,
-        KtTokens.RANGE_UNTIL -> {
-          if (isFirst) {
-            builder.open(expressionBreakIndent)
-          }
-          builder.token(leftExpression.operationReference.text)
-        }
-        KtTokens.ELVIS -> {
-          if (isFirst) {
-            builder.open(expressionBreakIndent)
-          }
-          builder.breakOp(Doc.FillMode.UNIFIED, " ", ZERO)
-          builder.token(leftExpression.operationReference.text)
-          builder.space()
-        }
-        else -> {
-          builder.space()
-          if (isFirst) {
-            builder.open(expressionBreakIndent)
-          }
-          builder.token(leftExpression.operationReference.text)
-          val fillMode =
-              if (leftExpression.operationReference.hasLineBreakingCommentBefore)
-                  Doc.FillMode.INDEPENDENT
-              else Doc.FillMode.UNIFIED
-          builder.breakOp(fillMode, " ", ZERO)
-        }
-      }
-      format(leftExpression.right)
+    val allExpressions = expression.fullChain
+    format(allExpressions.first().left)
+    for ((index, currentExpression) in allExpressions.withIndex()) {
+      formatBinaryOperationToken(currentExpression, index == 0)
+      format(currentExpression.right)
     }
     builder.close()
+  }
+
+  private fun formatBinaryOperationToken(expression: KtBinaryExpression, isFirst: Boolean = false) {
+    when (expression.operationToken) {
+      KtTokens.RANGE,
+      KtTokens.RANGE_UNTIL -> {
+        if (isFirst) {
+          builder.open(expressionBreakIndent)
+        }
+        builder.token(expression.operationReference.text)
+      }
+      KtTokens.ELVIS -> {
+        if (isFirst) {
+          builder.open(expressionBreakIndent)
+        }
+        builder.breakOp(Doc.FillMode.UNIFIED, " ", ZERO)
+        builder.token(expression.operationReference.text)
+        builder.space()
+      }
+      else -> {
+        builder.space()
+        if (isFirst) {
+          builder.open(expressionBreakIndent)
+        }
+        builder.token(expression.operationReference.text)
+        val fillMode =
+            if (expression.operationReference.hasLineBreakingCommentBefore) Doc.FillMode.INDEPENDENT
+            else Doc.FillMode.UNIFIED
+        builder.breakOp(fillMode, " ", ZERO)
+      }
+    }
   }
 
   override fun formatPostfixExpression(expression: KtPostfixExpression) {
@@ -191,9 +181,7 @@ interface ExpressionFormatter : KotlinAstFormatter {
   override fun formatLabeledExpression(expression: KtLabeledExpression) {
     builder.sync(expression)
     format(expression.labelQualifier)
-    if (expression.baseExpression !is KtLambdaExpression) {
-      builder.space()
-    }
+    if (expression.baseExpression !is KtLambdaExpression) builder.space()
     format(expression.baseExpression)
   }
 
@@ -202,7 +190,6 @@ interface ExpressionFormatter : KotlinAstFormatter {
     builder.token(expression.text)
   }
 
-  /** Example `(1 + 1)` */
   override fun formatParenthesizedExpression(expression: KtParenthesizedExpression) {
     builder.sync(expression)
     builder.token("(")
@@ -210,13 +197,11 @@ interface ExpressionFormatter : KotlinAstFormatter {
     builder.token(")")
   }
 
-  /** Example `"Hello $world!"` or `"""Hello world!"""` */
   override fun formatStringTemplateExpression(expression: KtStringTemplateExpression) {
     builder.sync(expression)
     builder.token(WhitespaceTombstones.replaceTrailingWhitespaceWithTombstone(expression.text))
   }
 
-  /** Example `super` in `super.doIt(5)` or `super<Foo>` in `super<Foo>.doIt(5)` */
   override fun formatSuperExpression(expression: KtSuperExpression) {
     builder.sync(expression)
     builder.token("super")
@@ -266,7 +251,6 @@ interface ExpressionFormatter : KotlinAstFormatter {
     builder.token("class")
   }
 
-  /** Example `a is Int` or `b !is Int` */
   override fun formatIsExpression(expression: KtIsExpression) {
     builder.sync(expression)
     val openGroupBeforeLeft = expression.leftHandSide !is KtQualifiedExpression
@@ -289,7 +273,6 @@ interface ExpressionFormatter : KotlinAstFormatter {
     builder.close()
   }
 
-  /** Example `a as Int` or `a as? Int` */
   override fun formatBinaryWithTypeRHSExpression(expression: KtBinaryExpressionWithTypeRHS) {
     builder.sync(expression)
     val openGroupBeforeLeft = expression.left !is KtQualifiedExpression
@@ -303,14 +286,6 @@ interface ExpressionFormatter : KotlinAstFormatter {
     builder.close()
   }
 
-  /**
-   * Example:
-   * ```
-   * fun f() {
-   *   val a: Array<Int> = [1, 2, 3]
-   * }
-   * ```
-   */
   override fun formatCollectionLiteralExpression(expression: KtCollectionLiteralExpression) {
     builder.sync(expression)
     builder.block(expressionBreakIndent) {

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/ExpressionFormatter.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/ExpressionFormatter.kt
@@ -1,8 +1,37 @@
 package org.jetbrains.ktfmt.format.visitor
 
 import com.google.googlejavaformat.Doc
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
+import org.jetbrains.kotlin.psi.KtClassLiteralExpression
+import org.jetbrains.kotlin.psi.KtCollectionLiteralExpression
+import org.jetbrains.kotlin.psi.KtConstantExpression
+import org.jetbrains.kotlin.psi.KtContainerNode
 import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtIsExpression
+import org.jetbrains.kotlin.psi.KtLabelReferenceExpression
+import org.jetbrains.kotlin.psi.KtLabeledExpression
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtParenthesizedExpression
+import org.jetbrains.kotlin.psi.KtPostfixExpression
+import org.jetbrains.kotlin.psi.KtPrefixExpression
+import org.jetbrains.kotlin.psi.KtQualifiedExpression
+import org.jetbrains.kotlin.psi.KtReferenceExpression
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.KtSuperExpression
+import org.jetbrains.kotlin.psi.KtThisExpression
+import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.ktfmt.format.WhitespaceTombstones
+import org.jetbrains.ktfmt.format.visitor.Indentation.Companion.ZERO
 
+/**
+ * Formatter that handles formatting of all basic **non-control flow** expressions. Exceptions:
+ * - Any function call-related expressions are handled in [CallFormatter]
+ */
 interface ExpressionFormatter : KotlinAstFormatter {
   override fun formatInitializerExpression(initializer: KtExpression) {
     builder.token("=")
@@ -21,6 +50,277 @@ interface ExpressionFormatter : KotlinAstFormatter {
         builder.fenceComments()
         format(initializer)
       }
+    }
+  }
+
+  /** Example `this` or `this@Foo` */
+  override fun formatThisExpression(expression: KtThisExpression) {
+    builder.sync(expression)
+    builder.token("this")
+    format(expression.getTargetLabel())
+  }
+
+  /** Example `Foo` or `@Foo` */
+  override fun formatSimpleNameExpression(expression: KtSimpleNameExpression) {
+    builder.sync(expression)
+    when (expression) {
+      is KtLabelReferenceExpression -> {
+        if (expression.text[0] == '@') {
+          builder.token("@")
+          builder.token(expression.getIdentifier()?.text ?: fail())
+        } else {
+          builder.token(expression.getIdentifier()?.text ?: fail())
+          builder.token("@")
+        }
+      }
+      else -> {
+        if (expression.text.isNotEmpty()) {
+          builder.token(expression.text)
+        }
+      }
+    }
+  }
+
+  override fun formatReferenceExpression(expression: KtReferenceExpression) {
+    builder.sync(expression)
+    builder.token(expression.text)
+  }
+
+  /**
+   * For example `a + b`, `a + b + c` or `a..b`
+   *
+   * The extra handling here drills to the left most expression and handles it for long chains of
+   * binary expressions that are formatted not accordingly to the associative values That is, we
+   * want to think of `a + b + c` as `(a + b) + c`, whereas the AST parses it as `a + (b + c)`
+   */
+  override fun formatBinaryExpression(expression: KtBinaryExpression) {
+    builder.sync(expression)
+    val op = expression.operationToken
+
+    if (KtTokens.ALL_ASSIGNMENTS.contains(op) && expression.right.isLambdaOrScopingFunction) {
+      // Assignments are statements in Kotlin; we don't have to worry about compound assignment.
+      format(expression.left)
+      builder.space()
+      builder.token(expression.operationReference.text)
+      formatLambdaOrScopingFunction(expression.right)
+      return
+    }
+
+    val parts =
+        ArrayDeque<KtBinaryExpression>().apply {
+          var current: KtExpression? = expression
+          while (current is KtBinaryExpression && current.operationToken == op) {
+            addFirst(current)
+            current = current.left
+          }
+        }
+
+    val leftMostExpression = parts.first()
+    format(leftMostExpression.left)
+    for (leftExpression in parts) {
+      val isFirst = leftExpression === leftMostExpression
+
+      when (leftExpression.operationToken) {
+        KtTokens.RANGE,
+        KtTokens.RANGE_UNTIL -> {
+          if (isFirst) {
+            builder.open(expressionBreakIndent)
+          }
+          builder.token(leftExpression.operationReference.text)
+        }
+        KtTokens.ELVIS -> {
+          if (isFirst) {
+            builder.open(expressionBreakIndent)
+          }
+          builder.breakOp(Doc.FillMode.UNIFIED, " ", ZERO)
+          builder.token(leftExpression.operationReference.text)
+          builder.space()
+        }
+        else -> {
+          builder.space()
+          if (isFirst) {
+            builder.open(expressionBreakIndent)
+          }
+          builder.token(leftExpression.operationReference.text)
+          val fillMode =
+              if (leftExpression.operationReference.hasLineBreakingCommentBefore)
+                  Doc.FillMode.INDEPENDENT
+              else Doc.FillMode.UNIFIED
+          builder.breakOp(fillMode, " ", ZERO)
+        }
+      }
+      format(leftExpression.right)
+    }
+    builder.close()
+  }
+
+  override fun formatPostfixExpression(expression: KtPostfixExpression) {
+    builder.sync(expression)
+    builder.block(ZERO) {
+      val baseExpression = expression.baseExpression
+      val operator = expression.operationReference.text
+
+      format(baseExpression)
+      if (
+          baseExpression is KtPostfixExpression &&
+              baseExpression.operationReference.text.last() == operator.first()
+      ) {
+        builder.space()
+      }
+      builder.token(operator)
+    }
+  }
+
+  override fun formatPrefixExpression(expression: KtPrefixExpression) {
+    builder.sync(expression)
+    builder.block(ZERO) {
+      val baseExpression = expression.baseExpression
+      val operator = expression.operationReference.text
+
+      builder.token(operator)
+      if (
+          baseExpression is KtPrefixExpression &&
+              operator.last() == baseExpression.operationReference.text.first()
+      ) {
+        builder.space()
+      }
+      format(baseExpression)
+    }
+  }
+
+  override fun formatLabeledExpression(expression: KtLabeledExpression) {
+    builder.sync(expression)
+    format(expression.labelQualifier)
+    if (expression.baseExpression !is KtLambdaExpression) {
+      builder.space()
+    }
+    format(expression.baseExpression)
+  }
+
+  override fun formatConstantExpression(expression: KtConstantExpression) {
+    builder.sync(expression)
+    builder.token(expression.text)
+  }
+
+  /** Example `(1 + 1)` */
+  override fun formatParenthesizedExpression(expression: KtParenthesizedExpression) {
+    builder.sync(expression)
+    builder.token("(")
+    format(expression.expression)
+    builder.token(")")
+  }
+
+  /** Example `"Hello $world!"` or `"""Hello world!"""` */
+  override fun formatStringTemplateExpression(expression: KtStringTemplateExpression) {
+    builder.sync(expression)
+    builder.token(WhitespaceTombstones.replaceTrailingWhitespaceWithTombstone(expression.text))
+  }
+
+  /** Example `super` in `super.doIt(5)` or `super<Foo>` in `super<Foo>.doIt(5)` */
+  override fun formatSuperExpression(expression: KtSuperExpression) {
+    builder.sync(expression)
+    builder.token("super")
+    val superTypeQualifier = expression.superTypeQualifier
+    if (superTypeQualifier != null) {
+      builder.token("<")
+      format(superTypeQualifier)
+      builder.token(">")
+    }
+    format(expression.labelQualifier)
+  }
+
+  /** Example `String::isNullOrEmpty` */
+  override fun formatCallableReferenceExpression(expression: KtCallableReferenceExpression) {
+    builder.sync(expression)
+    format(expression.receiverExpression)
+
+    // For some reason, expression.receiverExpression doesn't contain the question-mark token in
+    // case of a nullable type, e.g., in String?::isNullOrEmpty.
+    // Instead, KtCallableReferenceExpression exposes a method that looks for the QUEST token in
+    // its children.
+    if (expression.hasQuestionMarks) {
+      builder.token("?")
+    }
+
+    builder.block(expressionBreakIndent) {
+      builder.token("::")
+      builder.breakOp(Doc.FillMode.INDEPENDENT, "", ZERO)
+      format(expression.callableReference)
+    }
+  }
+
+  override fun formatClassLiteralExpression(expression: KtClassLiteralExpression) {
+    builder.sync(expression)
+    val receiverExpression = expression.receiverExpression
+    if (receiverExpression is KtCallExpression) {
+      formatFunctionCall(
+          receiverExpression.calleeExpression,
+          receiverExpression.typeArgumentList,
+          receiverExpression.valueArgumentList,
+          receiverExpression.trailingLambda,
+      )
+    } else {
+      format(receiverExpression)
+    }
+    builder.token("::")
+    builder.token("class")
+  }
+
+  /** Example `a is Int` or `b !is Int` */
+  override fun formatIsExpression(expression: KtIsExpression) {
+    builder.sync(expression)
+    val openGroupBeforeLeft = expression.leftHandSide !is KtQualifiedExpression
+    if (openGroupBeforeLeft) builder.open(ZERO)
+    format(expression.leftHandSide)
+    if (!openGroupBeforeLeft) builder.open(ZERO)
+    val parent = expression.parent
+    if (
+        parent is KtValueArgument ||
+            parent is KtParenthesizedExpression ||
+            parent is KtContainerNode
+    ) {
+      builder.breakOp(Doc.FillMode.UNIFIED, " ", expressionBreakIndent)
+    } else {
+      builder.space()
+    }
+    format(expression.operationReference)
+    builder.breakOp(Doc.FillMode.INDEPENDENT, " ", expressionBreakIndent)
+    builder.block(expressionBreakIndent) { format(expression.typeReference) }
+    builder.close()
+  }
+
+  /** Example `a as Int` or `a as? Int` */
+  override fun formatBinaryWithTypeRHSExpression(expression: KtBinaryExpressionWithTypeRHS) {
+    builder.sync(expression)
+    val openGroupBeforeLeft = expression.left !is KtQualifiedExpression
+    if (openGroupBeforeLeft) builder.open(ZERO)
+    format(expression.left)
+    if (!openGroupBeforeLeft) builder.open(ZERO)
+    builder.breakOp(Doc.FillMode.UNIFIED, " ", expressionBreakIndent)
+    format(expression.operationReference)
+    builder.breakOp(Doc.FillMode.INDEPENDENT, " ", expressionBreakIndent)
+    builder.block(expressionBreakIndent) { format(expression.right) }
+    builder.close()
+  }
+
+  /**
+   * Example:
+   * ```
+   * fun f() {
+   *   val a: Array<Int> = [1, 2, 3]
+   * }
+   * ```
+   */
+  override fun formatCollectionLiteralExpression(expression: KtCollectionLiteralExpression) {
+    builder.sync(expression)
+    builder.block(expressionBreakIndent) {
+      formatCommaSeparatedList(
+          expression.getInnerExpressions(),
+          forceMultiline = expression.trailingComma != null,
+          prefix = "[",
+          postfix = "]",
+          wrapInBlock = !options.manageTrailingCommas,
+      )
     }
   }
 }

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/FileFormatter.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/FileFormatter.kt
@@ -5,6 +5,8 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtScript
 import org.jetbrains.kotlin.psi.KtScriptInitializer
@@ -69,5 +71,57 @@ interface FileFormatter : KotlinAstFormatter {
       formatStatement(statement)
       markForPartialFormat()
     }
+  }
+
+  override fun formatPackageDirective(directive: KtPackageDirective) {
+    builder.sync(directive)
+    if (directive.packageKeyword == null) {
+      return
+    }
+    builder.token("package")
+    builder.space()
+    var first = true
+    for (packageName in directive.packageNames) {
+      if (first) {
+        first = false
+      } else {
+        builder.token(".")
+      }
+      builder.token(packageName.getIdentifier()?.text ?: packageName.getReferencedName())
+    }
+
+    builder.guessToken(";")
+    builder.forcedBreak()
+  }
+
+  /** Example `import com.foo.A` */
+  override fun formatImportDirective(directive: KtImportDirective) {
+    builder.sync(directive)
+    builder.token("import")
+    builder.space()
+
+    val importedReference = directive.importedReference
+    if (importedReference != null) {
+      inImport = true
+      format(importedReference)
+      inImport = false
+    }
+    if (directive.isAllUnder) {
+      builder.token(".")
+      builder.token("*")
+    }
+
+    // Possible alias.
+    val alias = directive.alias?.nameIdentifier
+    if (alias != null) {
+      builder.space()
+      builder.token("as")
+      builder.space()
+      builder.token(alias.text ?: fail())
+    }
+
+    // Force a newline afterwards.
+    builder.guessToken(";")
+    builder.forcedBreak()
   }
 }

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/FileFormatter.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/FileFormatter.kt
@@ -94,7 +94,6 @@ interface FileFormatter : KotlinAstFormatter {
     builder.forcedBreak()
   }
 
-  /** Example `import com.foo.A` */
   override fun formatImportDirective(directive: KtImportDirective) {
     builder.sync(directive)
     builder.token("import")

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/KotlinAstFormatter.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/KotlinAstFormatter.kt
@@ -475,8 +475,14 @@ interface KotlinAstFormatter {
   /**
    * Format the right-hand side of an initializer expression, i.e. the expression after `=`
    * (inclusively)
+   *
+   * @param assignmentOp The symbol that separates the initializer from the expression, see
+   *   [org.jetbrains.kotlin.lexer.KtTokens.ALL_ASSIGNMENTS]
    */
-  fun formatInitializerExpression(initializer: KtExpression)
+  fun formatInitializerExpression(
+      initializer: KtExpression,
+      assignmentOp: String = "=",
+  )
 
   /** See [isLambdaOrScopingFunction] for examples. */
   fun formatLambdaOrScopingFunction(expr: PsiElement?, emitLeadingBreak: Boolean = true)

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/KotlinAstFormatter.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/KotlinAstFormatter.kt
@@ -254,45 +254,27 @@ interface KotlinAstFormatter {
       brokeBeforeBrace: BreakTag?,
   )
 
-  fun formatThisExpression(expression: KtThisExpression) {
-    TODO("Unreachable code path")
-  }
+  fun formatThisExpression(expression: KtThisExpression)
 
-  fun formatSimpleNameExpression(expression: KtSimpleNameExpression) {
-    TODO("Unreachable code path")
-  }
+  fun formatSimpleNameExpression(expression: KtSimpleNameExpression)
 
-  fun formatReferenceExpression(expression: KtReferenceExpression) {
-    TODO("Unreachable code path")
-  }
+  fun formatReferenceExpression(expression: KtReferenceExpression)
 
   fun formatReturnExpression(expression: KtReturnExpression) {
     TODO("Unreachable code path")
   }
 
-  fun formatBinaryExpression(expression: KtBinaryExpression) {
-    TODO("Unreachable code path")
-  }
+  fun formatBinaryExpression(expression: KtBinaryExpression)
 
-  fun formatPostfixExpression(expression: KtPostfixExpression) {
-    TODO("Unreachable code path")
-  }
+  fun formatPostfixExpression(expression: KtPostfixExpression)
 
-  fun formatPrefixExpression(expression: KtPrefixExpression) {
-    TODO("Unreachable code path")
-  }
+  fun formatPrefixExpression(expression: KtPrefixExpression)
 
-  fun formatLabeledExpression(expression: KtLabeledExpression) {
-    TODO("Unreachable code path")
-  }
+  fun formatLabeledExpression(expression: KtLabeledExpression)
 
-  fun formatConstantExpression(expression: KtConstantExpression) {
-    TODO("Unreachable code path")
-  }
+  fun formatConstantExpression(expression: KtConstantExpression)
 
-  fun formatParenthesizedExpression(expression: KtParenthesizedExpression) {
-    TODO("Unreachable code path")
-  }
+  fun formatParenthesizedExpression(expression: KtParenthesizedExpression)
 
   fun formatWhenExpression(expression: KtWhenExpression) {
     TODO("Unreachable code path")
@@ -318,17 +300,11 @@ interface KotlinAstFormatter {
     TODO("Unreachable code path")
   }
 
-  fun formatArrayAccessExpression(expression: KtArrayAccessExpression) {
-    TODO("Unreachable code path")
-  }
+  fun formatArrayAccessExpression(expression: KtArrayAccessExpression)
 
-  fun formatStringTemplateExpression(expression: KtStringTemplateExpression) {
-    TODO("Unreachable code path")
-  }
+  fun formatStringTemplateExpression(expression: KtStringTemplateExpression)
 
-  fun formatSuperExpression(expression: KtSuperExpression) {
-    TODO("Unreachable code path")
-  }
+  fun formatSuperExpression(expression: KtSuperExpression)
 
   fun formatForExpression(expression: KtForExpression) {
     TODO("Unreachable code path")
@@ -350,25 +326,15 @@ interface KotlinAstFormatter {
     TODO("Unreachable code path")
   }
 
-  fun formatCallableReferenceExpression(expression: KtCallableReferenceExpression) {
-    TODO("Unreachable code path")
-  }
+  fun formatCallableReferenceExpression(expression: KtCallableReferenceExpression)
 
-  fun formatClassLiteralExpression(expression: KtClassLiteralExpression) {
-    TODO("Unreachable code path")
-  }
+  fun formatClassLiteralExpression(expression: KtClassLiteralExpression)
 
-  fun formatIsExpression(expression: KtIsExpression) {
-    TODO("Unreachable code path")
-  }
+  fun formatIsExpression(expression: KtIsExpression)
 
-  fun formatBinaryWithTypeRHSExpression(expression: KtBinaryExpressionWithTypeRHS) {
-    TODO("Unreachable code path")
-  }
+  fun formatBinaryWithTypeRHSExpression(expression: KtBinaryExpressionWithTypeRHS)
 
-  fun formatCollectionLiteralExpression(expression: KtCollectionLiteralExpression) {
-    TODO("Unreachable code path")
-  }
+  fun formatCollectionLiteralExpression(expression: KtCollectionLiteralExpression)
 
   fun formatTryExpression(expression: KtTryExpression) {
     TODO("Unreachable code path")
@@ -402,15 +368,11 @@ interface KotlinAstFormatter {
     TODO("Unreachable code path")
   }
 
-  fun formatPackageDirective(directive: KtPackageDirective) {
-    TODO("Unreachable code path")
-  }
+  fun formatPackageDirective(directive: KtPackageDirective)
 
   fun formatImportList(importList: KtImportList)
 
-  fun formatImportDirective(directive: KtImportDirective) {
-    TODO("Unreachable code path")
-  }
+  fun formatImportDirective(directive: KtImportDirective)
 
   fun formatAnnotatedExpression(expression: KtAnnotatedExpression)
 

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/PsiUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/PsiUtils.kt
@@ -316,3 +316,25 @@ internal val KtCallElement.trailingLambda: KtLambdaArgument?
     if (lambdas.size == 1) return lambdas.first()
     else throw ParseError("Maximum one trailing lambda is allowed", lambdaArguments[1])
   }
+
+/**
+ * Returns all parts of a binary expression chain. AST parses multi-operand expressions from right
+ * to left: `a + b + c + d == a + (b + (c + d))`, while formatter is interested in the order from
+ * left to right: `a + b + c + d == ((a + b) + c) + d`. So for given example this will return a list
+ * of three elements:
+ * ```
+ * 0. a + b
+ * 1. (a + b) + c
+ * 2. ((a + b) + c) + d
+ * ```
+ */
+internal val KtBinaryExpression.fullChain: List<KtBinaryExpression>
+  get() = buildList {
+    val op = operationToken
+    var current: KtExpression? = this@fullChain
+    while (current is KtBinaryExpression && current.operationToken == op) {
+      add(current)
+      current = current.left
+    }
+  }
+      .asReversed()

--- a/core/src/test/resources/cases/format/type/castsWithBreaks.input
+++ b/core/src/test/resources/cases/format/type/castsWithBreaks.input
@@ -40,3 +40,16 @@ fun castIt(
 val a =
     l.sOrNull() is
         SomethingLongEnough
+
+fun f() {
+  foo.bam()
+      .uber()
+      .boom() is Boo
+
+  doIt(
+      foo.bam()
+          .uber()
+          .boom()
+          .lah is Boo,
+  )
+}


### PR DESCRIPTION
* Extract expression formatting implementations to ExpressionFormatter
* Refactor the implementations
* Add a test case that covers `!openGroupBeforeLeft` branch of `formatIsExpression`