### PR TITLE
[build] Build cleanup

### DIFF
--- a/core/api/ktfmt.api
+++ b/core/api/ktfmt.api
@@ -92,7 +92,6 @@ public final class org/jetbrains/ktfmt/debughelpers/PrintAstVisitor : org/jetbra
 
 public final class org/jetbrains/ktfmt/format/EnumEntryList {
 	public static final field Companion Lorg/jetbrains/ktfmt/format/EnumEntryList$Companion;
-	public synthetic fun <init> (Ljava/util/List;Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getEnumEntries ()Ljava/util/List;
 	public final fun getTerminatingSemicolon ()Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;
 	public final fun getTrailingComma ()Lorg/jetbrains/kotlin/com/intellij/psi/PsiElement;

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import org.jetbrains.dokka.gradle.tasks.DokkaGeneratePublicationTask
 import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation
 import org.jetbrains.ktfmt.GenerateKtfmtFileTask
@@ -44,48 +45,43 @@ dependencies {
 
 val generateSources =
     tasks.register("generateSources") {
+      description = "Generate sources"
       outputs.dir(layout.buildDirectory.dir("generated/main/kotlin"))
       dependsOn(tasks.withType<GenerateKtfmtFileTask>())
     }
 
+// Match a correct source set by the current Kotlin version (e.g., 2.3.0-beta1 -> 2.3)
+val compatibilitySources = run {
+  val kotlinVersion = rootProject.libs.versions.kotlin.get().substringBeforeLast(".")
+  val sourceRoot = layout.projectDirectory.dir("src/main/kotlin-$kotlinVersion")
+  require(sourceRoot.asFile.isDirectory) {
+    "No compatibility sources for Kotlin $kotlinVersion: expected $sourceRoot."
+  }
+  sourceRoot
+}
+
 tasks {
-  // Run tests with UTF-16 encoding
   test {
     useJUnitPlatform()
     jvmArgs("-Dfile.encoding=UTF-16")
   }
 
-  // Handle multiple versions of Kotlin here
-  withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    // Only get major and minor version, e.g. 1.8.0-beta1 -> 1.8
-    val kotlinVersion = rootProject.libs.versions.kotlin.get().substringBeforeLast(".")
-    exclude {
-      val path = it.path
-      "org/jetbrains/ktfmt/util/kotlin-" in path && "kotlin-$kotlinVersion" !in path
-    }
-  }
-
-  // Add main class to jar manifest
   withType(Jar::class) { manifest { attributes["Main-Class"] = "org.jetbrains.ktfmt.cli.Main" } }
 
-  // Sources
-  register("sourcesJar", Jar::class) {
+  register<Jar>("sourcesJar") {
+    description = "Sources jar including generated sources and compatibility utils"
     archiveClassifier = "sources"
     from(sourceSets["main"].allSource)
   }
 
-  // Javadoc
-  register("javadocJar", Jar::class) {
-    val dokkaJavadocTask = named(
-        "dokkaGeneratePublicationJavadoc",
-        org.jetbrains.dokka.gradle.tasks.DokkaGeneratePublicationTask::class,
-    )
+  register<Jar>("javadocJar") {
+    description = "Dokka-generated Javadoc jar"
+    val dokkaJavadocTask = named<DokkaGeneratePublicationTask>("dokkaGeneratePublicationJavadoc")
     dependsOn(dokkaJavadocTask)
     from(dokkaJavadocTask.flatMap { it.outputDirectory })
     archiveClassifier = "javadoc"
   }
 
-  // Fat jar
   shadowJar {
     archiveClassifier = "with-dependencies"
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
@@ -104,8 +100,8 @@ kotlin {
   sourceSets {
     main {
       kotlin {
-        // Include generated code
         srcDir(generateSources)
+        srcDir(compatibilitySources)
       }
     }
   }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -90,7 +90,7 @@ tasks {
 }
 
 kotlin {
-  @OptIn(ExperimentalAbiValidation::class) abiValidation { enabled = true }
+  @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class) abiValidation()
 
   compilerOptions { jvmDefault = JvmDefaultMode.NO_COMPATIBILITY }
 

--- a/core/src/main/kotlin-2.1/org/jetbrains/ktfmt/util/CompatibilityUtils.kt
+++ b/core/src/main/kotlin-2.1/org/jetbrains/ktfmt/util/CompatibilityUtils.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:Suppress("IncorrectPackageName", "PackageDirectoryMismatch")
-
 package org.jetbrains.ktfmt.util
 
 import org.jetbrains.kotlin.psi.KtContextReceiverList

--- a/core/src/main/kotlin-2.2/org/jetbrains/ktfmt/util/CompatibilityUtils.kt
+++ b/core/src/main/kotlin-2.2/org/jetbrains/ktfmt/util/CompatibilityUtils.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:Suppress("IncorrectPackageName", "PackageDirectoryMismatch")
-
 package org.jetbrains.ktfmt.util
 
 import org.jetbrains.kotlin.psi.KtContextReceiverList
@@ -27,7 +25,8 @@ fun KtContextReceiverList.listToVisit(): List<KtElement> {
   return contextParameters().ifEmpty { contextReceivers() }
 }
 
-val CONTEXT_PARAMETER_LIST = KtStubElementTypes.CONTEXT_PARAMETER_LIST
+val CONTEXT_PARAMETER_LIST = KtStubElementTypes.CONTEXT_RECEIVER_LIST
 
+/** No val/var keyword in destructuring statements until Kotlin 2.3. */
 val KtDestructuringDeclarationEntry.ownValOrVarKeywordText: String?
-  get() = ownValOrVarKeyword?.text
+  get() = null

--- a/core/src/main/kotlin-2.3/org/jetbrains/ktfmt/util/CompatibilityUtils.kt
+++ b/core/src/main/kotlin-2.3/org/jetbrains/ktfmt/util/CompatibilityUtils.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:Suppress("IncorrectPackageName", "PackageDirectoryMismatch")
-
 package org.jetbrains.ktfmt.util
 
 import org.jetbrains.kotlin.psi.KtContextReceiverList
@@ -27,8 +25,7 @@ fun KtContextReceiverList.listToVisit(): List<KtElement> {
   return contextParameters().ifEmpty { contextReceivers() }
 }
 
-val CONTEXT_PARAMETER_LIST = KtStubElementTypes.CONTEXT_RECEIVER_LIST
+val CONTEXT_PARAMETER_LIST = KtStubElementTypes.CONTEXT_PARAMETER_LIST
 
-/** No val/var keyword in destructuring statements until Kotlin 2.3. */
 val KtDestructuringDeclarationEntry.ownValOrVarKeywordText: String?
-  get() = null
+  get() = ownValOrVarKeyword?.text

--- a/core/src/main/kotlin-2.4/org/jetbrains/ktfmt/util/CompatibilityUtils.kt
+++ b/core/src/main/kotlin-2.4/org/jetbrains/ktfmt/util/CompatibilityUtils.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.ktfmt.util
+
+import org.jetbrains.kotlin.psi.KtContextReceiverList
+import org.jetbrains.kotlin.psi.KtDestructuringDeclarationEntry
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
+
+fun KtContextReceiverList.listToVisit(): List<KtElement> {
+  return contextParameters.ifEmpty { contextReceivers() }
+}
+
+val CONTEXT_PARAMETER_LIST = KtStubElementTypes.CONTEXT_PARAMETER_LIST
+
+val KtDestructuringDeclarationEntry.ownValOrVarKeywordText: String?
+  get() = ownValOrVarKeyword?.text

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/Parser.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/Parser.kt
@@ -16,8 +16,10 @@
 
 package org.jetbrains.ktfmt.format
 
+import org.jetbrains.kotlin.K1Deprecation
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer.PLAIN_RELATIVE_PATHS
 import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
+import org.jetbrains.kotlin.cli.create
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
@@ -42,17 +44,22 @@ object Parser {
    * causing a worse memory leak before when we created new ones and disposed them. This leak comes
    * from [KotlinCoreEnvironment.createForProduction]:
    * https://github.com/JetBrains/kotlin/blob/master/compiler/cli/src/org/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment.kt#L544
+   *
+   * In the future release the [K1Deprecation] annotation is replaced by a new
+   * `CoreEnvironmentDeprecation` annotation that is not part of the K1 deprecation process.
+   * Therefore, we can rely on it until we migrate to the KMP parser or come up with a better
+   * solution. https://github.com/JetBrains/kotlin/commit/3d92fa98294055ba43e294d6e320630e18697c6e
    */
   val env: KotlinCoreEnvironment by lazy {
     // To hide annoying warning on Windows
     System.setProperty("idea.use.native.fs.for.win", "false")
     val disposable = Disposer.newDisposable()
-    val configuration = CompilerConfiguration()
+    val configuration = CompilerConfiguration.create()
     configuration.put(
         CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY,
         PrintingMessageCollector(System.err, PLAIN_RELATIVE_PATHS, false),
     )
-    @Suppress("OPT_IN_USAGE_ERROR") // KotlinCoreEnvironment.createForProduction
+    @OptIn(K1Deprecation::class)
     KotlinCoreEnvironment.createForProduction(
         disposable,
         configuration,

--- a/core/src/main/native-image/resources/META-INF/native-image/org/jetbrains/ktfmt/reachability-metadata.json
+++ b/core/src/main/native-image/resources/META-INF/native-image/org/jetbrains/ktfmt/reachability-metadata.json
@@ -663,6 +663,20 @@
       "type": "org.jetbrains.kotlin.psi.KtCollectionLiteralExpression[]"
     },
     {
+      "type": "org.jetbrains.kotlin.psi.KtCompanionBlock",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.jetbrains.kotlin.com.intellij.lang.ASTNode"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.jetbrains.kotlin.psi.KtCompanionBlock[]"
+    },
+    {
       "type": "org.jetbrains.kotlin.psi.KtConstantExpression",
       "methods": [
         {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 java = "17"
-kotlin = "2.3.20"
+kotlin = "2.4.10"
 com-google-googlejavaformat-google-java-format = "1.23.0"
 com-google-guava-guava = "33.5.0-jre"
 org-ec4j-core = "1.2.0"


### PR DESCRIPTION
* Extract Kotlin compatibility utils as separate source sets
* Add task descriptions
* Clean up unnecessary comments
* Update to Kotlin 2.4.10 (fixes #533)
  * Bundled Kotlin version update into this PR because it depends on the compatibility source sets change. I can split it into two separate PRs if necessary
