### PR TITLE
Refactor playground to use JVM ktfmt

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -8,6 +8,6 @@ Open <http://localhost:8000> and play with it.
 
 ## Implementation details
 
-Under the hood, it runs `./gradlew :ktfmt:nativeCompile` and starts a trivial
-python server that serves formatting requests using the built native image.
-Close to zero latency, easy to experiment with a new formatter and compare
+Under the hood, it runs `./gradlew :ktfmt:shadowJar` and starts a trivial
+python server that serves formatting requests by invoking `java -jar` on the
+built fat jar. Easy to experiment with a new formatter and compare

--- a/playground/run.sh
+++ b/playground/run.sh
@@ -1,22 +1,24 @@
 #!/usr/bin/env bash
-#   ./playground/run.sh                   # build + run
-#   ./playground/run.sh /path/to/ktfmt    # run with predefinied binary
+#   ./playground/run.sh                       # build + run
+#   ./playground/run.sh /path/to/ktfmt.jar    # run with a prebuilt jar
 
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_dir="$(cd "$script_dir/.." && pwd)"
 
-binary="${1:-}"
-if [[ -z "$binary" ]]; then
-  binary="$repo_dir/core/build/native/nativeCompile/ktfmt"
-  echo "Building the Native Image binary (this takes a few minutes on a cold build)..."
-  (cd "$repo_dir" && ./gradlew :ktfmt:nativeCompile)
+jar="${1:-}"
+if [[ -z "$jar" ]]; then
+  echo "Building the ktfmt jar..."
+  (cd "$repo_dir" && ./gradlew :ktfmt:shadowJar)
+
+  jars=("$repo_dir"/core/build/libs/ktfmt-*-with-dependencies.jar)
+  jar="${jars[0]}"
 fi
 
-if [[ ! -x "$binary" ]]; then
-  echo "No executable ktfmt binary at: $binary" >&2
+if [[ ! -f "$jar" ]]; then
+  echo "No ktfmt jar at: $jar" >&2
   exit 1
 fi
 
-exec python3 "$script_dir/server.py" "$binary"
+exec python3 "$script_dir/server.py" "$jar"

--- a/playground/server.py
+++ b/playground/server.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import os
+import shutil
 import subprocess
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
@@ -10,8 +11,8 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 PORT = 8000
 
-def do_format(binary, code, experimental):
-    args = [binary]
+def do_format(jar, code, experimental):
+    args = ["java", "-jar", jar]
     if experimental:
         args.append("--experimental-engine")
     args.append("-")
@@ -28,7 +29,7 @@ def do_format(binary, code, experimental):
 
 
 class PlaygroundHandler(SimpleHTTPRequestHandler):
-    binary = ""
+    jar = ""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, directory=str(SCRIPT_DIR), **kwargs)
@@ -41,8 +42,8 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
         length = int(self.headers.get("Content-Length") or 0)
         code = self.rfile.read(length).decode("utf-8", "replace")
 
-        default_ok, default_text = do_format(self.binary, code, experimental=False)
-        experimental_ok, experimental_text = do_format(self.binary, code, experimental=True)
+        default_ok, default_text = do_format(self.jar, code, experimental=False)
+        experimental_ok, experimental_text = do_format(self.jar, code, experimental=True)
         payload = json.dumps(
             {
                 "default": {"ok": default_ok, "text": default_text},
@@ -62,14 +63,16 @@ class PlaygroundHandler(SimpleHTTPRequestHandler):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("binary")
+    parser.add_argument("jar")
     args = parser.parse_args()
 
-    if not os.path.isfile(args.binary) or not os.access(args.binary, os.X_OK):
-        parser.error(f"not an executable ktfmt binary: {args.binary}")
+    if not os.path.isfile(args.jar):
+        parser.error(f"not a ktfmt jar: {args.jar}")
+    if shutil.which("java") is None:
+        parser.error("'java' not found on PATH")
 
-    PlaygroundHandler.binary = args.binary
-    print(f"ktfmt playground on http://localhost:{PORT}  (binary: {args.binary})")
+    PlaygroundHandler.jar = args.jar
+    print(f"ktfmt playground on http://localhost:{PORT}  (jar: {args.jar})")
     try:
         HTTPServer(("127.0.0.1", PORT), PlaygroundHandler).serve_forever()
     except KeyboardInterrupt:


### PR DESCRIPTION
While native image provides very fast reformatting, rebuilding it takes a lot of time. Which is not very convenient when experimenting with the style a lot