### PR TITLE
[format] Correctly handle `KtAnnotatedExpression` that contain both `…

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/AnnotationFormatter.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/AnnotationFormatter.kt
@@ -32,12 +32,12 @@ internal open class AnnotationFormatterImpl : AnnotationFormatter {
       val baseExpression = expression.baseExpression
 
       builder.block {
-        val annotationEntries = expression.annotationEntries
-        for (annotationEntry in annotationEntries) {
-          if (annotationEntry !== annotationEntries.first()) {
+        val annotations = expression.topLevelAnnotations
+        for ((index, annotation) in annotations.withIndex()) {
+          if (index > 0) {
             builder.breakOp(Doc.FillMode.UNIFIED, " ", ZERO)
           }
-          format(annotationEntry)
+          format(annotation)
         }
       }
 
@@ -58,8 +58,8 @@ internal open class AnnotationFormatterImpl : AnnotationFormatter {
   }
 
   /**
-   * A KtAnnotation is used only to group multiple annotations with the same use-site-target. It
-   * only appears in a modifier list since annotated expressions do not have use-site-targets.
+   * A KtAnnotation is used only to group multiple annotations with the same use-site-target, e.g.
+   * `@[A B] foo()`. It can appear in a modifier list or on an annotated expression.
    */
   context(_: FormatterStateHolder)
   override fun formatAnnotation(annotation: KtAnnotation) {

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/PsiUtils.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/PsiUtils.kt
@@ -22,6 +22,9 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.lexer.KtSingleValueToken
+import org.jetbrains.kotlin.psi.KtAnnotatedExpression
+import org.jetbrains.kotlin.psi.KtAnnotation
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtArrayAccessExpression
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
@@ -338,3 +341,24 @@ internal val KtBinaryExpression.fullChain: List<KtBinaryExpression>
     }
   }
       .asReversed()
+
+/**
+ * Returns all top-level annotations of an expression. Solves the problem that
+ * `KtAnnotatedExpression.annotations` only returns elements of type [KtAnnotation], and accordingly
+ * `KtAnnotatedExpression.annotationEntries` returns only elements of type [KtAnnotationEntry]. The
+ * problem arises when an expression contains both on top level:
+ * ```
+ * fun foo() {
+ *     @[A B] @C foo()
+ * }
+ * ```
+ *
+ * For this example
+ * - `KtAnnotatedExpression.annotations` returns `[KtAnnotation("@[A B]")]`
+ * - `KtAnnotatedExpression.annotationEntries` returns `[KtAnnotationEntry("A"),
+ *   KtAnnotationEntry("B"), KtAnnotationEntry("@C")]`
+ * - `KtAnnotatedExpression.topLevelAnnotations` will return `[KtAnnotation("@[A B]"),
+ *   KtAnnotationEntry("@C")]`
+ */
+internal val KtAnnotatedExpression.topLevelAnnotations: List<PsiElement>
+  get() = children.filter { it is KtAnnotation || it is KtAnnotationEntry }

--- a/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/kotlinlang/KotlinLangAnnotationFormatter.kt
+++ b/core/src/main/kotlin/org/jetbrains/ktfmt/format/visitor/kotlinlang/KotlinLangAnnotationFormatter.kt
@@ -14,6 +14,7 @@ import org.jetbrains.ktfmt.format.visitor.builder
 import org.jetbrains.ktfmt.format.visitor.format
 import org.jetbrains.ktfmt.format.visitor.isBinaryExpression
 import org.jetbrains.ktfmt.format.visitor.sync
+import org.jetbrains.ktfmt.format.visitor.topLevelAnnotations
 
 /**
  * Custom annotation expression formatter for KotlinLang style. For annotations on declarations and
@@ -42,8 +43,8 @@ internal class KotlinLangAnnotationFormatterImpl : AnnotationFormatterImpl() {
     val baseExpression = expression.baseExpression
 
     builder.block {
-      val annotationEntries = expression.annotationEntries
-      for ((index, annotationEntry) in annotationEntries.withIndex()) {
+      val annotations = expression.topLevelAnnotations
+      for ((index, annotationEntry) in annotations.withIndex()) {
         if (index > 0) {
           builder.breakOp(Doc.FillMode.UNIFIED, " ", ZERO)
         }

--- a/core/src/test/resources/cases/format/annotation/arrayOfAnnotationsOnExpression.input
+++ b/core/src/test/resources/cases/format/annotation/arrayOfAnnotationsOnExpression.input
@@ -1,0 +1,20 @@
+fun foo() {
+  @[Suppress("DEPRECATION") OptIn(ExperimentalContextReceivers::class)]
+  println("Hello, world!")
+
+  @[Suppress("DEPRECATION") OptIn(ExperimentalContextReceivers::class)]
+  @C
+  println("Hello, world!")
+
+  @C
+  @[Suppress("DEPRECATION") OptIn(ExperimentalContextReceivers::class)]
+  println("Hello, world!")
+
+  @[A B]
+  @C
+  println("Hello, world!")
+
+  @C
+  @[A B]
+  println("Hello, world!")
+}


### PR DESCRIPTION
…KtAnnotation` and `KtAnnotationEntry` at the top level

#696 fixed


Another solution is that maybe we just want to rewrite `@[A B] foo()` as `@A @B foo()`. But I think that is another topic for discussion. And, we will either (a) have to change the default style or (b) only implement this for kotlinlang style. (b) means that the default style will still fail with an exception on this example, so I think it still makes sense to implement this